### PR TITLE
fix: use master instead of main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 concurrency:
@@ -94,7 +94,7 @@ jobs:
       # Do a dry run of PSR
       - name: Test release
         uses: python-semantic-release/python-semantic-release@v9.8.1
-        if: github.ref_name != 'main'
+        if: github.ref_name != 'master'
         with:
           root_options: --noop
 
@@ -102,7 +102,7 @@ jobs:
       - name: Release
         uses: python-semantic-release/python-semantic-release@v9.8.1
         id: release
-        if: github.ref_name == 'main'
+        if: github.ref_name == 'master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/almoehi/larvaworld/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
The github action assumed that our main branch is called 'main'. But this is an older repository where the default branch is called 'master'.