### PR TITLE
feat: start semver at 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          #- "3.8"
-          #- "3.9"
-          #- "3.10"
+          - "3.8"
+          - "3.9"
+          - "3.10"
           - "3.11"
           # - "3.12"
         os:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,8 @@ version_variables = [
   "docs/conf.py:release",
 ]
 build_command = "pip install poetry && poetry build"
+allow_zero_version  = false
+
 
 [tool.semantic_release.changelog]
 exclude_commit_patterns = [


### PR DESCRIPTION


### Description of change
Configure python-semantic-release to start initial version at 1.0.0 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/almoehi/larvaworld/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
