### PR TITLE
feat(deps,sim,core): python 3.12 & 3.13 support, collision handling fixes, and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@
 - Added Python 3.13 support by updating Python version constraint from `">=3.10,<3.13"` to `">=3.10,<3.14"`.
 - Added `SALib <1.5.2` constraint to ensure compatibility with numpy 1.x.
 - Pinned `panel` to `"1.2.*"` (from `">=1.2,<2.0"`) to fix `larvaworld-app` hang issue on Python 3.12 and 3.13. Panel 1.8.x has compatibility issues with `pn.serve()` that prevent the web app from starting.
+- Fixed collision handling bugs: introduced `_has_larva_collision()` helper in `LarvaSim` and normalized shapes to Shapely geometries in `ExpRun.get_larva_bodies()`.
+- Added UI feedback for larva overlap toggle (keyboard shortcut `Y`).
+- Added simulation storage directory feedback via `vprint` messages (verbosity level 2) for all simulation types (Exp, Batch, GA, Eval).
+- Updated tests to use `reg.default_refID` instead of hardcoded dataset IDs for better flexibility.
+- Removed deprecation warning infrastructure (`LARVAWORLD_STRICT_DEPRECATIONS` checks) from 25 files (~288 lines removed).
+- Updated documentation: added publications page, improved contributing.md with commit message examples, removed outdated badges from README, updated Python version support across all docs.
+- Minor fixes: timer baseline alignment, module-level constant docstrings for autoapi, end-of-file formatting.
+- Updated `poetry.lock` to match `pyproject.toml` dependency changes.
 
 ## v2.0.1 (2025-11-25)
 


### PR DESCRIPTION
## Summary

This PR adds support for python 3.12 and 3.13, fixes critical collision handling bugs, improves user feedback, and cleans up legacy deprecation infrastructure. All changes are backward-compatible and tested across python 3.10–3.13.

## Key Changes

### 🐍 Python 3.12 & 3.13 Support
- **Dependency updates**: Relaxed version constraints to allow newer wheels compatible with python 3.12/3.13 while maintaining lower bounds
- **Panel compatibility fix**: Pinned Panel to `1.2.*` to fix `larvaworld-app` hanging issue on python 3.12/3.13
- **Video export**: Added `imageio[ffmpeg]` extra as core dependency (no longer optional)
- **SALib constraint**: Added `SALib <1.5.2` to maintain numpy 1.x compatibility
- **Documentation**: Updated all docs (README, installation.md, dependencies.md, index.rst) to reflect python 3.10–3.13 support

### 🐛 Collision Handling Fixes
- **LarvaSim collision detection**: Fixed `AttributeError` by introducing `_has_larva_collision()` helper method
- **Shape normalization**: Fixed collision checks by normalizing `CoordinateSequence` to Shapely geometries in `ExpRun.get_larva_bodies()`
- **UI feedback**: Added visual feedback when toggling larva overlap mode (keyboard shortcut `Y`)

### ✨ User Experience Improvements
- **Simulation storage feedback**: Added `vprint` messages (verbosity level 2) to all simulation types (Exp, Batch, GA, Eval) indicating where output files are saved
- **Test flexibility**: Updated tests to use `reg.default_refID` instead of hardcoded dataset IDs

### 🧹 Code Cleanup
- **Deprecation infrastructure removal**: Removed `LARVAWORLD_STRICT_DEPRECATIONS` checks and deprecation warnings from 25 files (~288 lines removed)
- **Import cleanup**: Removed unused `os` imports that were only needed for environment variable checks
- **Code formatting**: Applied formatting fixes (end-of-file, trailing whitespace, ruff-format)

## Testing

- ✅ Verified installation on python 3.10, 3.11, 3.12, and 3.13
- ✅ All tests pass on python 3.12 and 3.13
- ✅ `larvaworld-app` works correctly on all Python versions (fixed Panel compatibility)
- ✅ Collision handling works as expected (no more AttributeErrors)

## Known Issues

- **`eliminate_overlap()` bug**: Still needs fix for `l.get_polygon()` call (not python-version specific)

## Breaking Changes

None. All changes are backward-compatible.

## Related Issues

- Fixes `larvaworld-app` hanging on python 3.12/3.13
- Fixes collision detection AttributeErrors
- Enables python 3.12/3.13 support

## Documentation

- Updated `README.md` with python 3.10–3.13 support
- Updated `docs/installation.md` with modern venv examples
- Updated `docs/concepts/dependencies.md` with python version constraints
- Updated `docs/index.rst` Python version badge
- Updated `docs/contributing.md` with improved commit message format examples