### PR TITLE
feat(gui): deliver M1 desktop shell into work/2026q1-deliverables

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4037,6 +4037,63 @@ files = [
 certifi = "*"
 
 [[package]]
+name = "pyside6"
+version = "6.10.2"
+description = "Python bindings for the Qt cross-platform application and UI framework"
+optional = false
+python-versions = "<3.15,>=3.9"
+groups = ["main"]
+files = [
+    {file = "pyside6-6.10.2-cp39-abi3-macosx_13_0_universal2.whl", hash = "sha256:4b084293caa7845d0064aaf6af258e0f7caae03a14a33537d0a552131afddaf0"},
+    {file = "pyside6-6.10.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:1b89ce8558d4b4f35b85bff1db90d680912e4d3ce9e79ff804d6fef1d1a151ef"},
+    {file = "pyside6-6.10.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:0439f5e9b10ebe6177981bac9e219096ec970ac6ec215bef055279802ba50601"},
+    {file = "pyside6-6.10.2-cp39-abi3-win_amd64.whl", hash = "sha256:032bad6b18a17fcbf4dddd0397f49b07f8aae7f1a45b7e4de7037bf7fd6e0edf"},
+    {file = "pyside6-6.10.2-cp39-abi3-win_arm64.whl", hash = "sha256:65a59ad0bc92525639e3268d590948ce07a80ee97b55e7a9200db41d493cac31"},
+]
+
+[package.dependencies]
+PySide6_Addons = "6.10.2"
+PySide6_Essentials = "6.10.2"
+shiboken6 = "6.10.2"
+
+[[package]]
+name = "pyside6-addons"
+version = "6.10.2"
+description = "Python bindings for the Qt cross-platform application and UI framework (Addons)"
+optional = false
+python-versions = "<3.15,>=3.9"
+groups = ["main"]
+files = [
+    {file = "pyside6_addons-6.10.2-cp39-abi3-macosx_13_0_universal2.whl", hash = "sha256:0de7d0c9535e17d5e3b634b61314a1867f3b0f6d35c3d7cdc99efc353192faff"},
+    {file = "pyside6_addons-6.10.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:030a851163b51dbf0063be59e9ddb6a9e760bde89a28e461ccc81a224d286eaf"},
+    {file = "pyside6_addons-6.10.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:fcee0373e3fd7b98f014094e5e37b4a39e4de7c5a47c13f654a7d557d4a426ad"},
+    {file = "pyside6_addons-6.10.2-cp39-abi3-win_amd64.whl", hash = "sha256:c20150068525a17494f3b6576c5d61c417cf9a5870659e29f5ebd83cd20a78ea"},
+    {file = "pyside6_addons-6.10.2-cp39-abi3-win_arm64.whl", hash = "sha256:3d18db739b46946ba7b722d8ad4cc2097135033aa6ea57076e64d591e6a345f3"},
+]
+
+[package.dependencies]
+PySide6_Essentials = "6.10.2"
+shiboken6 = "6.10.2"
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.10.2"
+description = "Python bindings for the Qt cross-platform application and UI framework (Essentials)"
+optional = false
+python-versions = "<3.15,>=3.9"
+groups = ["main"]
+files = [
+    {file = "pyside6_essentials-6.10.2-cp39-abi3-macosx_13_0_universal2.whl", hash = "sha256:1dee2cb9803ff135f881dadeb5c0edcef793d1ec4f8a9140a1348cecb71074e1"},
+    {file = "pyside6_essentials-6.10.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:660aea45bfa36f1e06f799b934c2a7df963bd31abc5083e8bb8a5bfaef45686b"},
+    {file = "pyside6_essentials-6.10.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:c2b028e4c6f8047a02c31f373408e23b4eedfd405f56c6aba8d0525c29472835"},
+    {file = "pyside6_essentials-6.10.2-cp39-abi3-win_amd64.whl", hash = "sha256:0741018c2b6395038cad4c41775cfae3f13a409e87995ac9f7d89e5b1fb6b22a"},
+    {file = "pyside6_essentials-6.10.2-cp39-abi3-win_arm64.whl", hash = "sha256:db5f4913648bb6afddb8b347edae151ee2378f12bceb03c8b2515a530a4b38d9"},
+]
+
+[package.dependencies]
+shiboken6 = "6.10.2"
+
+[[package]]
 name = "pytest"
 version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
@@ -4916,6 +4973,21 @@ groups = ["main"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.10.2"
+description = "Python/C++ bindings helper module"
+optional = false
+python-versions = "<3.15,>=3.9"
+groups = ["main"]
+files = [
+    {file = "shiboken6-6.10.2-cp39-abi3-macosx_13_0_universal2.whl", hash = "sha256:3bd4e94e9a3c8c1fa8362fd752d399ef39265d5264e4e37bae61cdaa2a00c8c7"},
+    {file = "shiboken6-6.10.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ace0790032d9cb0adda644b94ee28d59410180d9773643bb6cf8438c361987ad"},
+    {file = "shiboken6-6.10.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:f74d3ed1f92658077d0630c39e694eb043aeb1d830a5d275176c45d07147427f"},
+    {file = "shiboken6-6.10.2-cp39-abi3-win_amd64.whl", hash = "sha256:10f3c8c5e1b8bee779346f21c10dbc14cff068f0b0b4e62420c82a6bf36ac2e7"},
+    {file = "shiboken6-6.10.2-cp39-abi3-win_arm64.whl", hash = "sha256:20c671645d70835af212ee05df60361d734c5305edb2746e9875c6a31283f963"},
 ]
 
 [[package]]
@@ -6058,4 +6130,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "64045c9045197420f2385ed4086d5f10b53fa3780293e86221bf176073609f6f"
+content-hash = "36d480061999683965c4819caed2a26833f63f302be4c92a6a799e5b167346f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ packages = [
 larvaworld = "larvaworld.cli.main:main"
 # Currently GUI is not functional
 # larvaworld-gui = "larvaworld.gui.main:main"
+larvaworld-gui-v2 = "larvaworld.gui_v2.main:main"
 larvaworld-app = "larvaworld.dashboards.main:main"
 larvaworld-portal = "larvaworld.portal.serve:main"
 
@@ -61,6 +62,7 @@ pint_pandas = ">=0.3,<1.0"
 powerlaw = "1.5"
 progressbar = "2.5"
 pygame = ">=2.6,<3.0"
+PySide6 = ">=6.8,<7.0"
 pypdf = ">=5.0,<6.0"
 # PySimpleGUI is now located on a private PyPI server.  Please add to your pip command: -i https://PySimpleGUI.net/install
 #PySimpleGUI = "*"

--- a/src/larvaworld/gui_v2/__init__.py
+++ b/src/larvaworld/gui_v2/__init__.py
@@ -1,0 +1,1 @@
+"""Modernized desktop GUI shell scaffold for Larvaworld."""

--- a/src/larvaworld/gui_v2/apps/__init__.py
+++ b/src/larvaworld/gui_v2/apps/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/larvaworld/gui_v2/apps/models_environments/__init__.py
+++ b/src/larvaworld/gui_v2/apps/models_environments/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/larvaworld/gui_v2/apps/models_environments/environment_builder.py
+++ b/src/larvaworld/gui_v2/apps/models_environments/environment_builder.py
@@ -1,0 +1,857 @@
+from __future__ import annotations
+
+from larvaworld.gui_v2.registry_bridge import GuiEntry
+from PySide6.QtCore import QPointF, QRectF, Qt
+from PySide6.QtGui import QBrush, QColor, QFont, QPen
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
+    QFrame,
+    QGraphicsEllipseItem,
+    QGraphicsLineItem,
+    QGraphicsRectItem,
+    QGraphicsScene,
+    QGraphicsView,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+def build_environment_builder_text(
+    entry: GuiEntry,
+) -> tuple[str, str, list[tuple[str, str]]]:
+    badges = ", ".join(entry.badges) if entry.badges else "None"
+    docs = entry.docs_url or "No documentation link registered."
+
+    blocks = [
+        (
+            "Rough gui_v2 composition",
+            "The gui_v2 Environment Builder should likely be assembled from three legacy building blocks: "
+            "environment configuration, interactive arena drawing, and body/agent drawing. "
+            "This is a rough composition study, not final integration yet.",
+        ),
+        (
+            "Legacy source mapping",
+            "1. `src/larvaworld/gui/tabs/env.py`\n"
+            "   - structured environment configuration editor\n"
+            "   - arena, food groups/units, borders, odorscape, windscape\n\n"
+            "2. `src/larvaworld/gui/tabs/env_draw.py`\n"
+            "   - interactive arena/environment drawing tab\n"
+            "   - add food, larvae, borders\n"
+            "   - move / inspect / erase items on canvas\n\n"
+            "3. `src/larvaworld/gui/tabs/body_draw.py`\n"
+            "   - interactive body/agent drawing tab\n"
+            "   - body points, segments, sensor positions\n"
+            "   - useful if Environment Builder grows into agent-placement/body-related editing",
+        ),
+        (
+            "Provisional gui_v2 interpretation",
+            "Near-term rough mapping inside gui_v2 could be:\n"
+            "- Environment setup tab/pane from `env.py`\n"
+            "- Arena drawing surface from `env_draw.py`\n"
+            "- Optional secondary body editor surface from `body_draw.py`\n\n"
+            "This suggests that the current browser-side Environment Builder and the legacy desktop editors "
+            "should eventually converge into one desktop-native composite tool.",
+        ),
+        (
+            "Current shared metadata",
+            f"Lane: {entry.lane_title}\n"
+            f"Kind: {entry.kind}\n"
+            f"Status: {entry.status}\n"
+            f"Level: {entry.level}\n"
+            f"CTA: {entry.cta}\n"
+            f"Badges: {badges}\n"
+            f"Docs: {docs}",
+        ),
+    ]
+
+    return entry.title, "Rough legacy-to-gui_v2 mapping view.", blocks
+
+
+def build_environment_builder_widget(entry: GuiEntry) -> QWidget:
+    host = QWidget()
+    layout = QVBoxLayout(host)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(14)
+
+    intro = _card(
+        "Composition study",
+        "Rough gui_v2 Environment Builder composition that maps the legacy desktop editors into "
+        "one integrated shell-native tool. The `Arena draw` tab below is now a first interactive "
+        "prototype based on the legacy `env_draw.py` interaction model.",
+    )
+    layout.addWidget(intro)
+
+    tabs = QTabWidget()
+    tabs.setDocumentMode(True)
+    tabs.setStyleSheet(
+        """
+        QTabWidget::pane {
+            border: 1px solid #d1d5db;
+            background: #ffffff;
+            border-radius: 10px;
+        }
+        QTabBar::tab {
+            background: #f3f4f6;
+            color: #374151;
+            border: 1px solid #d1d5db;
+            padding: 8px 14px;
+            margin-right: 6px;
+            border-top-left-radius: 8px;
+            border-top-right-radius: 8px;
+            font-weight: 600;
+        }
+        QTabBar::tab:selected {
+            background: #ede9f0;
+            color: #111827;
+            border-color: #c1b0c2;
+        }
+        """
+    )
+    tabs.addTab(_environment_setup_tab(), "Environment setup")
+    tabs.addTab(_arena_draw_tab(), "Arena draw")
+    tabs.addTab(_body_draw_tab(), "Body draw")
+    layout.addWidget(tabs)
+
+    meta = _card(
+        "Shared metadata",
+        f"Lane: {entry.lane_title} · Status: {entry.status} · Level: {entry.level} · "
+        f"CTA: {entry.cta} · Docs: {entry.docs_url or 'No documentation link registered.'}",
+    )
+    layout.addWidget(meta)
+    layout.addStretch(1)
+    return host
+
+
+def _environment_setup_tab() -> QWidget:
+    host = QWidget()
+    layout = QVBoxLayout(host)
+    layout.setContentsMargins(16, 16, 16, 16)
+    layout.setSpacing(14)
+
+    layout.addWidget(_card("Legacy source", "`src/larvaworld/gui/tabs/env.py`"))
+
+    grid = QWidget()
+    grid_layout = QGridLayout(grid)
+    grid_layout.setContentsMargins(0, 0, 0, 0)
+    grid_layout.setHorizontalSpacing(12)
+    grid_layout.setVerticalSpacing(12)
+    grid_layout.addWidget(
+        _mini_panel("Arena", "shape · dimensions · reset/new arena"), 0, 0
+    )
+    grid_layout.addWidget(_mini_panel("Food", "groups · units · food grid"), 0, 1)
+    grid_layout.addWidget(_mini_panel("Borders", "border list · ids · geometry"), 1, 0)
+    grid_layout.addWidget(_mini_panel("Fields", "odorscape · windscape"), 1, 1)
+    layout.addWidget(grid)
+
+    layout.addWidget(
+        _card(
+            "Proposed gui_v2 role",
+            "Configuration pane that stays docked next to the drawing surface. It should host the "
+            "structured environment metadata while the user edits the arena visually.",
+        )
+    )
+    layout.addStretch(1)
+    return host
+
+
+def _arena_draw_tab() -> QWidget:
+    return ArenaDrawPrototype()
+
+
+def _body_draw_tab() -> QWidget:
+    host = QWidget()
+    layout = QVBoxLayout(host)
+    layout.setContentsMargins(16, 16, 16, 16)
+    layout.setSpacing(14)
+
+    layout.addWidget(_card("Legacy source", "`src/larvaworld/gui/tabs/body_draw.py`"))
+
+    row = QHBoxLayout()
+    row.setContentsMargins(0, 0, 0, 0)
+    row.setSpacing(12)
+    row.addWidget(
+        _mini_panel("Body config", "points · segments · olfaction · touch sensors"), 0
+    )
+    row.addWidget(_body_mock(), 1)
+    layout.addLayout(row)
+
+    layout.addWidget(
+        _card(
+            "Possible fit inside Environment Builder",
+            "Body drawing may stay optional rather than always visible. It is still useful as a related "
+            "editor if Environment Builder evolves into a broader arena + agent-placement desktop tool.",
+        )
+    )
+    layout.addStretch(1)
+    return host
+
+
+class ArenaCanvasView(QGraphicsView):
+    def __init__(self, scene: QGraphicsScene, owner: "ArenaDrawPrototype") -> None:
+        super().__init__(scene)
+        self.owner = owner
+        self.setRenderHints(self.renderHints())
+        self.setStyleSheet(
+            "background:#ffffff;border:1px solid #cbd5e1;border-radius:8px;"
+        )
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        position = self.mapToScene(event.position().toPoint())
+        self.owner.handle_canvas_click(position)
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        super().mouseReleaseEvent(event)
+        self.owner.handle_canvas_release()
+
+
+class ArenaDrawPrototype(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.scene_width = 620
+        self.scene_height = 380
+        self.scene = QGraphicsScene(0, 0, self.scene_width, self.scene_height)
+        self.arena_rect: QGraphicsRectItem | None = None
+        self.arena_circle: QGraphicsEllipseItem | None = None
+        self.preview_point: QGraphicsEllipseItem | None = None
+        self.pending_border_start: QPointF | None = None
+        self.item_records: dict[str, dict[str, object]] = {}
+        self.tool_buttons: dict[str, QPushButton] = {}
+        self.mode_buttons: dict[str, QPushButton] = {}
+        self.current_tool = "food"
+        self.current_mode = "add"
+        self.info_label = QLabel()
+        self.action_label = QLabel()
+        self.arena_shape = "rectangular"
+        self.arena_width_m = 0.20
+        self.arena_height_m = 0.20
+        self.current_color = "#4caf50"
+        self.border_width_m = 0.001
+
+        self.shape_combo = QComboBox()
+        self.width_spin = QDoubleSpinBox()
+        self.height_spin = QDoubleSpinBox()
+        self.object_id_edit = QLineEdit()
+        self.color_combo = QComboBox()
+        self.border_width_spin = QDoubleSpinBox()
+
+        self._build()
+        self._draw_arena()
+        self._refresh_control_visibility()
+        self._sync_object_id()
+        self._sync_buttons()
+        self._set_info(
+            "Legacy env_draw-style prototype. Add Food, Larva, or Border items directly on the canvas."
+        )
+        self._set_action("Ready.")
+
+    def _build(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(14)
+
+        layout.addWidget(
+            _card("Legacy source", "`src/larvaworld/gui/tabs/env_draw.py`")
+        )
+
+        row = QHBoxLayout()
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(12)
+        layout.addLayout(row)
+
+        controls = QFrame()
+        controls.setFixedWidth(250)
+        controls.setStyleSheet(
+            "background:#f8fafc;border:1px solid #cbd5e1;border-radius:10px;"
+        )
+        controls_layout = QVBoxLayout(controls)
+        controls_layout.setContentsMargins(14, 14, 14, 14)
+        controls_layout.setSpacing(12)
+
+        controls_layout.addWidget(_section_label("Arena"))
+        arena_row = QHBoxLayout()
+        arena_row.setContentsMargins(0, 0, 0, 0)
+        arena_row.setSpacing(8)
+        self.shape_combo.addItems(["rectangular", "circular"])
+        self.shape_combo.currentTextChanged.connect(self._on_arena_changed)
+        arena_row.addWidget(self.shape_combo, 1)
+        reset_button = QPushButton("Reset")
+        reset_button.clicked.connect(self._reset_arena)
+        new_button = QPushButton("New")
+        new_button.clicked.connect(self._new_arena)
+        reset_button.setStyleSheet(_button_style(False, "#b0b4c2"))
+        new_button.setStyleSheet(_button_style(False, "#b0b4c2"))
+        arena_row.addWidget(reset_button)
+        arena_row.addWidget(new_button)
+        controls_layout.addLayout(arena_row)
+
+        dim_row = QHBoxLayout()
+        dim_row.setContentsMargins(0, 0, 0, 0)
+        dim_row.setSpacing(8)
+        self.width_spin.setDecimals(2)
+        self.width_spin.setRange(0.05, 1.0)
+        self.width_spin.setSingleStep(0.05)
+        self.width_spin.setValue(self.arena_width_m)
+        self.width_spin.setPrefix("W ")
+        self.width_spin.valueChanged.connect(self._on_arena_changed)
+        self.height_spin.setDecimals(2)
+        self.height_spin.setRange(0.05, 1.0)
+        self.height_spin.setSingleStep(0.05)
+        self.height_spin.setValue(self.arena_height_m)
+        self.height_spin.setPrefix("H ")
+        self.height_spin.valueChanged.connect(self._on_arena_changed)
+        dim_row.addWidget(self.width_spin)
+        dim_row.addWidget(self.height_spin)
+        controls_layout.addLayout(dim_row)
+
+        controls_layout.addWidget(_section_label("Insert object"))
+        id_row = QHBoxLayout()
+        id_row.setContentsMargins(0, 0, 0, 0)
+        id_row.setSpacing(8)
+        self.object_id_edit.setPlaceholderText("Object id")
+        id_row.addWidget(self.object_id_edit, 1)
+        controls_layout.addLayout(id_row)
+
+        controls_layout.addWidget(_section_label("Insert object"))
+        for tool_id, label in (
+            ("food", "Food"),
+            ("larva", "Larva"),
+            ("border", "Border segment"),
+        ):
+            button = QPushButton(label)
+            button.clicked.connect(
+                lambda _checked=False, value=tool_id: self._set_tool(value)
+            )
+            self.tool_buttons[tool_id] = button
+            controls_layout.addWidget(button)
+
+        self.color_combo.addItems(["green", "black", "orange", "magenta", "blue"])
+        self.color_combo.currentTextChanged.connect(self._on_color_changed)
+        controls_layout.addWidget(self.color_combo)
+        self.current_color = _named_color(self.color_combo.currentText())
+
+        self.border_width_spin.setDecimals(4)
+        self.border_width_spin.setRange(0.0005, 0.01)
+        self.border_width_spin.setSingleStep(0.0005)
+        self.border_width_spin.setValue(self.border_width_m)
+        self.border_width_spin.setPrefix("Border width ")
+        self.border_width_spin.setSuffix(" m")
+        self.border_width_spin.valueChanged.connect(self._on_border_width_changed)
+        controls_layout.addWidget(self.border_width_spin)
+
+        controls_layout.addSpacing(4)
+        controls_layout.addWidget(_section_label("Action mode"))
+        for mode_id, label in (
+            ("add", "Add"),
+            ("move", "Move"),
+            ("inspect", "Inspect"),
+            ("erase", "Erase"),
+        ):
+            button = QPushButton(label)
+            button.clicked.connect(
+                lambda _checked=False, value=mode_id: self._set_mode(value)
+            )
+            self.mode_buttons[mode_id] = button
+            controls_layout.addWidget(button)
+
+        controls_layout.addSpacing(4)
+        controls_layout.addWidget(_section_label("Quick source note"))
+        source_note = QLabel(
+            "This prototype mirrors the legacy env_draw logic more closely than the browser-side "
+            "Environment Builder: Food, Larva, and Border tools are taken directly from the old desktop tab."
+        )
+        source_note.setWordWrap(True)
+        source_note.setStyleSheet("color:#4b5563;border:none;")
+        source_note.setFont(_font(10, False))
+        controls_layout.addWidget(source_note)
+        controls_layout.addStretch(1)
+        row.addWidget(controls, 0)
+
+        canvas_frame = QFrame()
+        canvas_frame.setStyleSheet(
+            "background:#f8fafc;border:1px solid #cbd5e1;border-radius:10px;"
+        )
+        canvas_layout = QVBoxLayout(canvas_frame)
+        canvas_layout.setContentsMargins(14, 14, 14, 14)
+        canvas_layout.setSpacing(10)
+
+        title = QLabel("Arena drawing surface")
+        title.setFont(_font(12, True))
+        title.setStyleSheet("color:#111827;border:none;")
+        canvas_layout.addWidget(title)
+
+        subtitle = QLabel(
+            "First interactive gui_v2 prototype derived from env_draw behavior. Border segments require two clicks."
+        )
+        subtitle.setWordWrap(True)
+        subtitle.setStyleSheet("color:#4b5563;border:none;")
+        subtitle.setFont(_font(10, False))
+        canvas_layout.addWidget(subtitle)
+
+        view = ArenaCanvasView(self.scene, self)
+        view.setMinimumHeight(340)
+        canvas_layout.addWidget(view, 1)
+
+        self.info_label.setWordWrap(True)
+        self.info_label.setStyleSheet(
+            "background:#ffffff;color:#374151;border:1px solid #d1d5db;border-radius:8px;padding:10px;"
+        )
+        self.info_label.setFont(_font(10, False))
+        canvas_layout.addWidget(self.info_label)
+
+        self.action_label.setWordWrap(True)
+        self.action_label.setStyleSheet(
+            "background:#ffffff;color:#374151;border:1px solid #d1d5db;border-radius:8px;padding:10px;"
+        )
+        self.action_label.setFont(_font(10, False))
+        canvas_layout.addWidget(self.action_label)
+
+        row.addWidget(canvas_frame, 1)
+
+        layout.addWidget(
+            _card(
+                "Proposed gui_v2 role",
+                "Primary interactive surface for arena geometry and object placement. This first pass is "
+                "native PySide6, but it is explicitly driven by the legacy env_draw interaction pattern.",
+            )
+        )
+        layout.addStretch(1)
+
+    def _draw_arena(self) -> None:
+        if self.arena_rect is not None:
+            self.scene.removeItem(self.arena_rect)
+            self.arena_rect = None
+        if self.arena_circle is not None:
+            self.scene.removeItem(self.arena_circle)
+            self.arena_circle = None
+        pen = QPen(QColor("#6b7280"))
+        pen.setWidth(2)
+        rect = self._arena_scene_rect()
+        if self.arena_shape == "circular":
+            diameter = min(rect.width(), rect.height())
+            x = rect.center().x() - diameter / 2
+            y = rect.center().y() - diameter / 2
+            self.arena_circle = self.scene.addEllipse(
+                x,
+                y,
+                diameter,
+                diameter,
+                pen,
+                QBrush(QColor("#ffffff")),
+            )
+        else:
+            self.arena_rect = self.scene.addRect(rect, pen, QBrush(QColor("#ffffff")))
+
+    def _set_tool(self, tool_id: str) -> None:
+        self.current_tool = tool_id
+        self.pending_border_start = None
+        self._clear_preview()
+        self._refresh_control_visibility()
+        self._sync_object_id()
+        self._sync_buttons()
+        self._set_info(f"Insert tool set to {self.tool_buttons[tool_id].text()}.")
+
+    def _set_mode(self, mode_id: str) -> None:
+        self.current_mode = mode_id
+        self.pending_border_start = None
+        self._clear_preview()
+        self._sync_buttons()
+        self._set_items_movable(mode_id == "move")
+        self._set_action(f"Action mode set to {self.mode_buttons[mode_id].text()}.")
+
+    def _sync_buttons(self) -> None:
+        for tool_id, button in self.tool_buttons.items():
+            active = tool_id == self.current_tool
+            button.setStyleSheet(_button_style(active, "#c1b0c2"))
+        for mode_id, button in self.mode_buttons.items():
+            active = mode_id == self.current_mode
+            button.setStyleSheet(_button_style(active, "#b0b4c2"))
+
+    def _set_info(self, message: str) -> None:
+        self.info_label.setText(message)
+
+    def _set_action(self, message: str) -> None:
+        self.action_label.setText(message)
+
+    def _set_items_movable(self, movable: bool) -> None:
+        for record in self.item_records.values():
+            item = record["item"]
+            item.setFlag(item.GraphicsItemFlag.ItemIsMovable, movable)
+
+    def _on_arena_changed(self, *_args) -> None:
+        self.arena_shape = self.shape_combo.currentText()
+        self.arena_width_m = float(self.width_spin.value())
+        self.arena_height_m = float(self.height_spin.value())
+        self._draw_arena()
+        self._set_info(
+            f"Arena updated to {self.arena_shape} with dimensions "
+            f"{self.arena_width_m:.2f}m × {self.arena_height_m:.2f}m."
+        )
+
+    def _on_color_changed(self, color_name: str) -> None:
+        self.current_color = _named_color(color_name)
+
+    def _on_border_width_changed(self, value: float) -> None:
+        self.border_width_m = float(value)
+
+    def _refresh_control_visibility(self) -> None:
+        self.border_width_spin.setVisible(self.current_tool == "border")
+
+    def _reset_arena(self) -> None:
+        for record in self.item_records.values():
+            self.scene.removeItem(record["item"])
+        self.item_records.clear()
+        self.pending_border_start = None
+        self._clear_preview()
+        self._draw_arena()
+        self._sync_object_id()
+        self._set_action("Arena has been reset.")
+
+    def _new_arena(self) -> None:
+        self._reset_arena()
+        self._set_action("New arena initialized. All items erased.")
+
+    def _arena_scene_rect(self) -> QRectF:
+        margin_x = 70
+        margin_y = 40
+        available_w = self.scene_width - 2 * margin_x
+        available_h = self.scene_height - 2 * margin_y
+        if self.arena_shape == "circular":
+            diameter = min(available_w, available_h)
+            return self.scene.sceneRect().adjusted(
+                (self.scene_width - diameter) / 2,
+                (self.scene_height - diameter) / 2,
+                -(self.scene_width - diameter) / 2,
+                -(self.scene_height - diameter) / 2,
+            )
+        ratio = self.arena_width_m / max(self.arena_height_m, 1e-6)
+        draw_w = available_w
+        draw_h = draw_w / ratio
+        if draw_h > available_h:
+            draw_h = available_h
+            draw_w = draw_h * ratio
+        x = (self.scene_width - draw_w) / 2
+        y = (self.scene_height - draw_h) / 2
+        return QRectF(x, y, draw_w, draw_h)
+
+    def _is_inside_arena(self, position: QPointF) -> bool:
+        if self.arena_circle is not None:
+            circle = self.arena_circle.rect()
+            center = circle.center()
+            radius = circle.width() / 2
+            dx = position.x() - center.x()
+            dy = position.y() - center.y()
+            return (dx * dx + dy * dy) <= radius * radius
+        if self.arena_rect is not None:
+            return self.arena_rect.rect().contains(position)
+        return False
+
+    def _to_logical(self, position: QPointF) -> tuple[float, float]:
+        rect = self._arena_scene_rect()
+        rel_x = (position.x() - rect.center().x()) / max(rect.width(), 1e-6)
+        rel_y = (rect.center().y() - position.y()) / max(rect.height(), 1e-6)
+        return rel_x * self.arena_width_m, rel_y * self.arena_height_m
+
+    def handle_canvas_click(self, position: QPointF) -> None:
+        if self.arena_rect is None and self.arena_circle is None:
+            return
+        if not self._is_inside_arena(position):
+            return
+
+        clicked_items = [
+            item
+            for item in self.scene.items(position)
+            if item not in {self.arena_rect, self.arena_circle, self.preview_point}
+        ]
+
+        if self.current_mode == "inspect":
+            self._inspect_item(clicked_items, position)
+            return
+        if self.current_mode == "erase":
+            self._erase_item(clicked_items)
+            return
+        if self.current_mode == "move":
+            self._set_action(
+                "Move mode active. Drag existing items directly on the canvas."
+            )
+            return
+
+        if self.current_tool == "border":
+            self._handle_border_click(position)
+            return
+
+        self._add_point_item(position, self.current_tool)
+
+    def _add_point_item(self, position: QPointF, item_type: str) -> None:
+        color = self.current_color
+        radius = 9 if item_type == "food" else 7
+        item = self.scene.addEllipse(
+            position.x() - radius,
+            position.y() - radius,
+            radius * 2,
+            radius * 2,
+            QPen(QColor(color)),
+            QBrush(QColor(color)),
+        )
+        item_id = self.object_id_edit.text().strip() or self._next_object_id(item_type)
+        item.setData(0, item_type)
+        item.setData(1, item_id)
+        self.item_records[item_id] = {
+            "type": item_type,
+            "item": item,
+            "color": color,
+            "logical": self._to_logical(position),
+        }
+        self._set_items_movable(self.current_mode == "move")
+        lx, ly = self.item_records[item_id]["logical"]
+        self._set_action(
+            f"{item_type.title()} {item_id} placed at ({lx:.4f}, {ly:.4f})."
+        )
+        self._sync_object_id()
+
+    def _handle_border_click(self, position: QPointF) -> None:
+        if self.pending_border_start is None:
+            self.pending_border_start = position
+            self._clear_preview()
+            self.preview_point = self.scene.addEllipse(
+                position.x() - 4,
+                position.y() - 4,
+                8,
+                8,
+                QPen(QColor("#111111")),
+                QBrush(QColor("#111111")),
+            )
+            self._set_info(
+                "Border start point placed. Click a second point to finish the segment."
+            )
+            return
+
+        item_id = self.object_id_edit.text().strip() or self._next_object_id("border")
+        line = self.scene.addLine(
+            self.pending_border_start.x(),
+            self.pending_border_start.y(),
+            position.x(),
+            position.y(),
+            QPen(QColor(self.current_color), max(2, int(self.border_width_m * 2000))),
+        )
+        line.setData(0, "border")
+        line.setData(1, item_id)
+        self.item_records[item_id] = {
+            "type": "border",
+            "item": line,
+            "color": self.current_color,
+            "width": self.border_width_m,
+            "logical_points": (
+                self._to_logical(self.pending_border_start),
+                self._to_logical(position),
+            ),
+        }
+        self.pending_border_start = None
+        self._clear_preview()
+        self._set_items_movable(self.current_mode == "move")
+        p1, p2 = self.item_records[item_id]["logical_points"]
+        self._set_action(
+            f"Border {item_id} placed from ({p1[0]:.4f}, {p1[1]:.4f}) to ({p2[0]:.4f}, {p2[1]:.4f})."
+        )
+        self._sync_object_id()
+
+    def _inspect_item(self, clicked_items: list[object], position: QPointF) -> None:
+        if not clicked_items:
+            lx, ly = self._to_logical(position)
+            self._set_action(f"Inspect mode: no item at ({lx:.4f}, {ly:.4f}).")
+            return
+        item = clicked_items[0]
+        item_type = item.data(0) or "unknown"
+        item_id = item.data(1) or "unknown"
+        if isinstance(item, QGraphicsLineItem):
+            logical = self.item_records.get(item_id, {}).get("logical_points")
+            if logical is not None:
+                p1, p2 = logical
+                self._set_action(
+                    f"Inspect border {item_id}: ({p1[0]:.4f}, {p1[1]:.4f}) -> ({p2[0]:.4f}, {p2[1]:.4f})."
+                )
+                return
+            line = item.line()
+            self._set_action(
+                f"Inspect border segment: ({line.x1():.1f}, {line.y1():.1f}) -> ({line.x2():.1f}, {line.y2():.1f})."
+            )
+            return
+        logical = self.item_records.get(item_id, {}).get("logical")
+        if logical is not None:
+            self._set_action(
+                f"Inspect {item_type} {item_id}: ({logical[0]:.4f}, {logical[1]:.4f})."
+            )
+            return
+        rect = item.rect()
+        self._set_action(
+            f"Inspect {item_type}: center ≈ ({rect.center().x() + item.pos().x():.1f}, {rect.center().y() + item.pos().y():.1f})."
+        )
+
+    def _erase_item(self, clicked_items: list[object]) -> None:
+        if not clicked_items:
+            self._set_action("Erase mode: no item selected.")
+            return
+        target = clicked_items[0]
+        item_id = target.data(1)
+        self.scene.removeItem(target)
+        if item_id in self.item_records:
+            self.item_records.pop(item_id)
+        item_type = target.data(0) or "item"
+        self._set_action(f"Item {item_id or item_type} erased.")
+        self._sync_object_id()
+
+    def handle_canvas_release(self) -> None:
+        if self.current_mode != "move":
+            return
+        moved = False
+        for record in self.item_records.values():
+            item = record["item"]
+            if isinstance(item, QGraphicsLineItem):
+                line = item.line()
+                offset = item.pos()
+                p1 = QPointF(line.x1() + offset.x(), line.y1() + offset.y())
+                p2 = QPointF(line.x2() + offset.x(), line.y2() + offset.y())
+                logical_points = (self._to_logical(p1), self._to_logical(p2))
+                if record.get("logical_points") != logical_points:
+                    record["logical_points"] = logical_points
+                    moved = True
+            else:
+                rect = item.rect()
+                center = rect.center() + item.pos()
+                logical = self._to_logical(center)
+                if record.get("logical") != logical:
+                    record["logical"] = logical
+                    moved = True
+        if moved:
+            self._set_action("Item positions updated after drag.")
+
+    def _clear_preview(self) -> None:
+        if self.preview_point is not None:
+            self.scene.removeItem(self.preview_point)
+            self.preview_point = None
+
+    def _next_object_id(self, item_type: str) -> str:
+        prefix = {"food": "Food", "larva": "Larva", "border": "Border"}.get(
+            item_type, "Item"
+        )
+        count = 1
+        while f"{prefix}_{count}" in self.item_records:
+            count += 1
+        return f"{prefix}_{count}"
+
+    def _sync_object_id(self) -> None:
+        self.object_id_edit.setText(self._next_object_id(self.current_tool))
+
+
+def _body_mock() -> QWidget:
+    frame = QFrame()
+    frame.setMinimumHeight(280)
+    frame.setStyleSheet(
+        "background:#f8fafc;border:1px solid #cbd5e1;border-radius:10px;"
+    )
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(16, 16, 16, 16)
+    layout.setSpacing(10)
+
+    title = QLabel("Body geometry surface")
+    title.setFont(_font(12, True))
+    title.setStyleSheet("color:#111827;border:none;")
+    layout.addWidget(title)
+
+    canvas = QLabel(
+        "Body placeholder\n\n- points\n- segments\n- sensors\n- direct drag editing"
+    )
+    canvas.setAlignment(Qt.AlignCenter)
+    canvas.setStyleSheet(
+        "background:#ffffff;color:#475569;border:1px dashed #94a3b8;border-radius:8px;padding:24px;"
+    )
+    canvas.setMinimumHeight(180)
+    layout.addWidget(canvas, 1)
+    return frame
+
+
+def _mini_panel(title: str, body: str) -> QWidget:
+    frame = QFrame()
+    frame.setStyleSheet(
+        "background:#ffffff;border:1px solid #d1d5db;border-radius:10px;"
+    )
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(14, 12, 14, 12)
+    layout.setSpacing(8)
+
+    title_label = QLabel(title)
+    title_label.setFont(_font(11, True))
+    title_label.setStyleSheet("color:#111827;border:none;")
+    layout.addWidget(title_label)
+
+    body_label = QLabel(body)
+    body_label.setWordWrap(True)
+    body_label.setStyleSheet("color:#4b5563;border:none;")
+    body_label.setFont(_font(10, False))
+    layout.addWidget(body_label)
+    return frame
+
+
+def _section_label(text: str) -> QLabel:
+    label = QLabel(text)
+    label.setFont(_font(10, True))
+    label.setStyleSheet("color:#111827;border:none;")
+    return label
+
+
+def _button_style(active: bool, accent: str) -> str:
+    if active:
+        return (
+            f"background:{accent};color:#111827;border:1px solid #9ca3af;"
+            "border-radius:8px;padding:8px 12px;font-weight:600;"
+        )
+    return (
+        "background:#ffffff;color:#374151;border:1px solid #d1d5db;"
+        "border-radius:8px;padding:8px 12px;"
+    )
+
+
+def _named_color(name: str) -> str:
+    return {
+        "green": "#4caf50",
+        "black": "#111111",
+        "orange": "#f59e0b",
+        "magenta": "#d946ef",
+        "blue": "#2563eb",
+    }.get(name, "#4caf50")
+
+
+def _card(title: str, body: str) -> QWidget:
+    frame = QFrame()
+    frame.setStyleSheet(
+        "background:#ffffff;border:1px solid #d1d5db;border-radius:10px;"
+    )
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(14, 12, 14, 12)
+    layout.setSpacing(8)
+
+    title_label = QLabel(title)
+    title_label.setFont(_font(12, True))
+    title_label.setStyleSheet("color:#111827;border:none;")
+    layout.addWidget(title_label)
+
+    body_label = QLabel(body)
+    body_label.setWordWrap(True)
+    body_label.setTextFormat(Qt.PlainText)
+    body_label.setStyleSheet("color:#374151;border:none;")
+    body_label.setFont(_font(10, False))
+    layout.addWidget(body_label)
+    return frame
+
+
+def _font(size: int, bold: bool) -> QFont:
+    font = QFont("Helvetica", size)
+    font.setBold(bold)
+    return font

--- a/src/larvaworld/gui_v2/gui_aux/__init__.py
+++ b/src/larvaworld/gui_v2/gui_aux/__init__.py
@@ -1,0 +1,5 @@
+"""gui_v2 GUI helpers package.
+
+This package starts intentionally small. Legacy helpers should be copied or adapted
+only when they are needed by the new shell.
+"""

--- a/src/larvaworld/gui_v2/main.py
+++ b/src/larvaworld/gui_v2/main.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Launch the Larvaworld gui_v2 desktop shell.")
+    parser.add_argument(
+        "--geometry",
+        default="1360x860",
+        help="Window geometry in WIDTHxHEIGHT form.",
+    )
+    args = parser.parse_args()
+
+    try:
+        from larvaworld.gui_v2.shell import LarvaworldGuiV2Shell
+    except ModuleNotFoundError as exc:
+        if exc.name and exc.name.startswith("PySide6"):
+            raise RuntimeError(
+                "gui_v2 requires PySide6 in the active Python environment. "
+                "Install the project dependencies again after adding PySide6."
+            ) from exc
+        raise
+
+    shell = LarvaworldGuiV2Shell(geometry=args.geometry)
+    shell.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/larvaworld/gui_v2/registry_bridge.py
+++ b/src/larvaworld/gui_v2/registry_bridge.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from larvaworld.portal.landing_registry import ITEMS, LANES, QUICK_START_MODES
+from larvaworld.portal.registry_logic import compute_badges, validate_registry
+from larvaworld.portal.registry_types import LandingItem, QuickStartModeSpec
+
+
+@dataclass(frozen=True)
+class GuiEntry:
+    entry_id: str
+    title: str
+    subtitle: str
+    lane_title: str
+    lane_key: str
+    level: str
+    status: str
+    kind: str
+    badges: tuple[str, ...]
+    cta: str
+    panel_app_id: str | None
+    docs_url: str | None
+
+
+@dataclass(frozen=True)
+class GuiQuickStartMode:
+    mode_id: str
+    title: str
+    color: str
+    entries: tuple[GuiEntry, ...]
+
+
+@dataclass(frozen=True)
+class GuiLane:
+    lane_id: str
+    title: str
+    entries: tuple[GuiEntry, ...]
+
+
+@dataclass(frozen=True)
+class GuiNavigationModel:
+    quick_start_modes: tuple[GuiQuickStartMode, ...]
+    lanes: tuple[GuiLane, ...]
+    entry_index: dict[str, GuiEntry]
+
+
+def _build_entry(item: LandingItem) -> GuiEntry:
+    lane_title = next(
+        (lane.title for lane in LANES if lane.lane == item.lane), item.lane
+    )
+    learn_more = item.learn_more.docs_url if item.learn_more else None
+    return GuiEntry(
+        entry_id=item.id,
+        title=item.title,
+        subtitle=item.subtitle,
+        lane_title=lane_title,
+        lane_key=item.lane,
+        level=item.level,
+        status=item.status,
+        kind=item.kind,
+        badges=tuple(compute_badges(item)),
+        cta=item.cta,
+        panel_app_id=item.panel_app_id,
+        docs_url=learn_more,
+    )
+
+
+def _build_quick_start_mode(
+    mode: QuickStartModeSpec, entry_index: dict[str, GuiEntry]
+) -> GuiQuickStartMode:
+    return GuiQuickStartMode(
+        mode_id=mode.mode_id,
+        title=mode.title,
+        color=mode.color,
+        entries=tuple(entry_index[item_id] for item_id in mode.item_ids),
+    )
+
+
+def build_navigation_model() -> GuiNavigationModel:
+    validate_registry(strict=False)
+
+    entry_index = {item_id: _build_entry(item) for item_id, item in ITEMS.items()}
+    quick_start_modes = tuple(
+        _build_quick_start_mode(mode, entry_index) for mode in QUICK_START_MODES
+    )
+    lanes = tuple(
+        GuiLane(
+            lane_id=lane.lane,
+            title=lane.title,
+            entries=tuple(entry_index[item_id] for item_id in lane.item_ids),
+        )
+        for lane in LANES
+    )
+
+    return GuiNavigationModel(
+        quick_start_modes=quick_start_modes,
+        lanes=lanes,
+        entry_index=entry_index,
+    )

--- a/src/larvaworld/gui_v2/shell.py
+++ b/src/larvaworld/gui_v2/shell.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import importlib.metadata as im
+
+from larvaworld.gui_v2.registry_bridge import (
+    GuiEntry,
+    GuiNavigationModel,
+    build_navigation_model,
+)
+from larvaworld.gui_v2.tabs.home import build_home_text, build_home_widget
+from larvaworld.gui_v2.tabs.placeholder import (
+    build_entry_text,
+    build_entry_widget,
+    build_group_text,
+)
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QScrollArea,
+    QSplitter,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class LarvaworldGuiV2Shell:
+    def __init__(self, *, geometry: str = "1360x860") -> None:
+        self.model = build_navigation_model()
+        self.app = QApplication.instance() or QApplication([])
+        self.window = QMainWindow()
+        self.window.setWindowTitle("Larvaworld gui_v2")
+        width, height = self._parse_geometry(geometry)
+        self.window.resize(width, height)
+        self.window.setMinimumSize(1100, 760)
+
+        self._tree_payload: dict[str, tuple[str, str | GuiEntry | tuple[str, str]]] = {}
+        self._block_widgets: list[QWidget] = []
+        self._nav_collapsed = False
+        self._nav_expanded_width = 320
+
+        self._build_layout()
+        self._populate_tree()
+        self._select_default_view()
+
+    def run(self) -> None:
+        self.window.show()
+        self.app.exec()
+
+    def _build_layout(self) -> None:
+        root = QWidget()
+        root_layout = QVBoxLayout(root)
+        root_layout.setContentsMargins(0, 0, 0, 0)
+        root_layout.setSpacing(0)
+        root.setStyleSheet("background:#f3f4f6;")
+        self.window.setCentralWidget(root)
+
+        topbar = QFrame()
+        topbar.setFixedHeight(56)
+        topbar.setStyleSheet("background:#1f2937;")
+        topbar_layout = QHBoxLayout(topbar)
+        topbar_layout.setContentsMargins(18, 0, 18, 0)
+        topbar_layout.setSpacing(10)
+        root_layout.addWidget(topbar)
+
+        self.nav_toggle_button = QPushButton("◀")
+        self.nav_toggle_button.setFixedSize(34, 34)
+        self.nav_toggle_button.setCursor(Qt.PointingHandCursor)
+        self.nav_toggle_button.setStyleSheet(
+            "background:#111827;color:#f9fafb;border:1px solid #4b5563;border-radius:8px;font-size:16px;font-weight:700;"
+        )
+        self.nav_toggle_button.clicked.connect(self._toggle_navigation)
+        topbar_layout.addWidget(self.nav_toggle_button)
+
+        version = self._resolve_version()
+        title = QLabel(f"Larvaworld gui_v2  ·  v{version}")
+        title.setStyleSheet("color:#f9fafb;")
+        title.setFont(self._font(16, True))
+        topbar_layout.addWidget(title)
+
+        subtitle = QLabel("M1 desktop shell scaffold")
+        subtitle.setStyleSheet("color:#cbd5e1;")
+        subtitle.setFont(self._font(10, False))
+        topbar_layout.addWidget(subtitle)
+        topbar_layout.addStretch(1)
+
+        self.main_splitter = QSplitter(Qt.Horizontal)
+        self.main_splitter.setChildrenCollapsible(False)
+        self.main_splitter.setHandleWidth(6)
+        root_layout.addWidget(self.main_splitter, 1)
+
+        self.nav_frame = QFrame()
+        self.nav_frame.setMinimumWidth(280)
+        self.nav_frame.setMaximumWidth(380)
+        self.nav_frame.setStyleSheet("background:#e5e7eb;")
+        nav_layout = QVBoxLayout(self.nav_frame)
+        nav_layout.setContentsMargins(0, 0, 0, 0)
+        nav_layout.setSpacing(0)
+
+        nav_header = QLabel("Navigation")
+        nav_header.setStyleSheet("background:#d1d5db;color:#111827;padding:12px;")
+        nav_header.setFont(self._font(13, True))
+        nav_layout.addWidget(nav_header)
+
+        self.nav_tree = QTreeWidget()
+        self.nav_tree.setHeaderHidden(True)
+        self.nav_tree.setIndentation(18)
+        self.nav_tree.setStyleSheet(
+            """
+            QTreeWidget {
+                background:#e5e7eb;
+                border:none;
+                padding:8px;
+                color:#111827;
+                font-size:11px;
+            }
+            QTreeWidget::item {
+                height:24px;
+            }
+            QTreeWidget::item:selected {
+                background:#d1d5db;
+                color:#111827;
+            }
+            """
+        )
+        self.nav_tree.itemSelectionChanged.connect(self._on_tree_select)
+        nav_layout.addWidget(self.nav_tree, 1)
+
+        content_frame = QWidget()
+        content_frame.setStyleSheet("background:#ffffff;")
+        content_layout = QVBoxLayout(content_frame)
+        content_layout.setContentsMargins(14, 14, 14, 14)
+        content_layout.setSpacing(8)
+
+        self.content_header = QFrame()
+        self.content_header.setMinimumHeight(112)
+        self.content_header.setStyleSheet("background:#ede9f0;border-radius:10px;")
+        header_layout = QVBoxLayout(self.content_header)
+        header_layout.setContentsMargins(16, 14, 16, 14)
+        header_layout.setSpacing(6)
+        content_layout.addWidget(self.content_header)
+
+        self.content_title = QLabel("")
+        self.content_title.setStyleSheet("color:#111827;")
+        self.content_title.setFont(self._font(20, True))
+        header_layout.addWidget(self.content_title)
+
+        self.content_subtitle = QLabel("")
+        self.content_subtitle.setStyleSheet("color:#374151;")
+        self.content_subtitle.setFont(self._font(11, False))
+        self.content_subtitle.setWordWrap(True)
+        header_layout.addWidget(self.content_subtitle)
+
+        self.content_scroll = QScrollArea()
+        self.content_scroll.setWidgetResizable(True)
+        self.content_scroll.setFrameShape(QFrame.NoFrame)
+        self.content_scroll.setStyleSheet("background:#ffffff;")
+        content_layout.addWidget(self.content_scroll, 1)
+
+        self.content_body = QWidget()
+        self.content_body_layout = QVBoxLayout(self.content_body)
+        self.content_body_layout.setContentsMargins(0, 0, 0, 0)
+        self.content_body_layout.setSpacing(12)
+        self.content_body_layout.addStretch(1)
+        self.content_scroll.setWidget(self.content_body)
+
+        self.main_splitter.addWidget(self.nav_frame)
+        self.main_splitter.addWidget(content_frame)
+        self.main_splitter.setSizes([self._nav_expanded_width, 980])
+
+        footer = QLabel(
+            "Desktop-only shell · Shared portal metadata bridge · No external browser flow"
+        )
+        footer.setStyleSheet("background:#111827;color:#e5e7eb;padding:6px 12px;")
+        footer.setFont(self._font(9, False))
+        root_layout.addWidget(footer)
+
+    def _populate_tree(self) -> None:
+        self._tree_payload["home"] = ("home", None)
+        home_item = QTreeWidgetItem(["Home"])
+        home_item.setData(0, Qt.UserRole, "home")
+        self.nav_tree.addTopLevelItem(home_item)
+
+        quick_start_id = "group:quick_start"
+        self._tree_payload[quick_start_id] = (
+            "group",
+            ("Quick Start", "Portal-aligned quick-start modes and priority workflows."),
+        )
+        quick_start_item = QTreeWidgetItem(["Quick Start"])
+        quick_start_item.setData(0, Qt.UserRole, quick_start_id)
+        self.nav_tree.addTopLevelItem(quick_start_item)
+        quick_start_item.setExpanded(True)
+
+        for mode in self.model.quick_start_modes:
+            mode_id = f"mode:{mode.mode_id}"
+            self._tree_payload[mode_id] = (
+                "group",
+                (
+                    mode.title,
+                    f"Mode color {mode.color} · Contains {len(mode.entries)} quick-start workflows.",
+                ),
+            )
+            mode_item = QTreeWidgetItem([mode.title])
+            mode_item.setData(0, Qt.UserRole, mode_id)
+            quick_start_item.addChild(mode_item)
+            mode_item.setExpanded(True)
+            for entry in mode.entries:
+                item_id = f"entry:{mode.mode_id}:{entry.entry_id}"
+                self._tree_payload[item_id] = ("entry", entry)
+                entry_item = QTreeWidgetItem([entry.title])
+                entry_item.setData(0, Qt.UserRole, item_id)
+                mode_item.addChild(entry_item)
+
+        for lane in self.model.lanes:
+            lane_id = f"lane:{lane.lane_id}"
+            self._tree_payload[lane_id] = (
+                "group",
+                (
+                    lane.title,
+                    f"{len(lane.entries)} workflows in the {lane.title} group.",
+                ),
+            )
+            lane_item = QTreeWidgetItem([lane.title])
+            lane_item.setData(0, Qt.UserRole, lane_id)
+            self.nav_tree.addTopLevelItem(lane_item)
+            lane_item.setExpanded(True)
+            for entry in lane.entries:
+                item_id = f"entry:{lane.lane_id}:{entry.entry_id}"
+                self._tree_payload[item_id] = ("entry", entry)
+                entry_item = QTreeWidgetItem([entry.title])
+                entry_item.setData(0, Qt.UserRole, item_id)
+                lane_item.addChild(entry_item)
+
+    def _select_default_view(self) -> None:
+        home_item = self.nav_tree.topLevelItem(0)
+        self.nav_tree.setCurrentItem(home_item)
+        self._show_home_view()
+
+    def _on_tree_select(self) -> None:
+        item = self.nav_tree.currentItem()
+        if item is None:
+            return
+
+        node_id = item.data(0, Qt.UserRole)
+        payload = self._tree_payload.get(node_id)
+        if payload is None:
+            return
+
+        payload_kind, payload_value = payload
+        if payload_kind == "home":
+            self._show_home_view()
+        elif payload_kind == "group":
+            title, body = payload_value
+            self._show_group_view(title, body)
+        else:
+            self._show_entry_view(payload_value)
+
+    def _show_home_view(self) -> None:
+        title, subtitle, _blocks = build_home_text(self.model)
+        self._set_header(title, subtitle)
+        self._clear_body()
+        self._add_widget(
+            build_home_widget(self.model, on_entry_selected=self._show_entry_by_id)
+        )
+
+    def _show_group_view(self, title: str, description: str) -> None:
+        block_title, subtitle, blocks = build_group_text(title, description, self.model)
+        self._set_header(block_title, subtitle)
+        self._clear_body()
+
+        for inner_title, inner_body in blocks:
+            self._add_block(inner_title, inner_body)
+
+    def _show_entry_view(self, entry: GuiEntry) -> None:
+        title, subtitle, blocks = build_entry_text(entry)
+        self._set_header(title, subtitle)
+        self._clear_body()
+
+        widget = build_entry_widget(entry)
+        if widget is not None:
+            self._add_widget(widget)
+            return
+
+        for block_title, block_body in blocks:
+            self._add_block(block_title, block_body)
+
+    def _set_header(self, title: str, subtitle: str) -> None:
+        self.content_title.setText(title)
+        self.content_subtitle.setText(subtitle)
+
+    def _clear_body(self) -> None:
+        while self.content_body_layout.count():
+            item = self.content_body_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        self._block_widgets.clear()
+        self.content_body_layout.addStretch(1)
+
+    def _add_block(self, title: str, body: str) -> None:
+        stretch = self.content_body_layout.takeAt(self.content_body_layout.count() - 1)
+
+        outer = QFrame()
+        outer.setFrameShape(QFrame.StyledPanel)
+        outer.setStyleSheet(
+            "background:#ffffff;border:1px solid #d1d5db;border-radius:8px;"
+        )
+        outer_layout = QVBoxLayout(outer)
+        outer_layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout.setSpacing(0)
+
+        header = QLabel(title)
+        header.setStyleSheet(
+            "background:#f3f4f6;color:#111827;padding:8px 12px;border-top-left-radius:8px;border-top-right-radius:8px;"
+        )
+        header.setFont(self._font(12, True))
+        outer_layout.addWidget(header)
+
+        content = QLabel(body)
+        content.setStyleSheet("background:#ffffff;color:#374151;padding:12px;")
+        content.setFont(self._font(11, False))
+        content.setWordWrap(True)
+        content.setTextFormat(Qt.PlainText)
+        outer_layout.addWidget(content)
+
+        self.content_body_layout.addWidget(outer)
+        self._block_widgets.append(outer)
+        if stretch is not None:
+            self.content_body_layout.addItem(stretch)
+
+    def _add_widget(self, widget: QWidget) -> None:
+        stretch = self.content_body_layout.takeAt(self.content_body_layout.count() - 1)
+        self.content_body_layout.addWidget(widget)
+        self._block_widgets.append(widget)
+        if stretch is not None:
+            self.content_body_layout.addItem(stretch)
+
+    def _show_entry_by_id(self, entry_id: str) -> None:
+        entry = self.model.entry_index.get(entry_id)
+        if entry is None:
+            return
+        self._show_entry_view(entry)
+
+    def _toggle_navigation(self) -> None:
+        if self._nav_collapsed:
+            self.nav_frame.setMinimumWidth(280)
+            self.nav_frame.setMaximumWidth(380)
+            self.main_splitter.setSizes([self._nav_expanded_width, 1000])
+            self.nav_toggle_button.setText("◀")
+            self._nav_collapsed = False
+            return
+
+        current_width = self.main_splitter.sizes()[0]
+        if current_width > 0:
+            self._nav_expanded_width = current_width
+        self.nav_frame.setMinimumWidth(0)
+        self.nav_frame.setMaximumWidth(0)
+        self.main_splitter.setSizes([0, 1280])
+        self.nav_toggle_button.setText("▶")
+        self._nav_collapsed = True
+
+    @staticmethod
+    def _resolve_version() -> str:
+        try:
+            return im.version("larvaworld")
+        except Exception:
+            return "dev"
+
+    @staticmethod
+    def _parse_geometry(geometry: str) -> tuple[int, int]:
+        try:
+            width_str, height_str = geometry.lower().split("x", maxsplit=1)
+            return max(1100, int(width_str)), max(760, int(height_str))
+        except Exception:
+            return 1360, 860
+
+    @staticmethod
+    def _font(size: int, bold: bool) -> QFont:
+        font = QFont("Helvetica", size)
+        font.setBold(bold)
+        return font

--- a/src/larvaworld/gui_v2/tabs/__init__.py
+++ b/src/larvaworld/gui_v2/tabs/__init__.py
@@ -1,0 +1,4 @@
+from larvaworld.gui_v2.tabs.home import build_home_text
+from larvaworld.gui_v2.tabs.placeholder import build_entry_text, build_group_text
+
+__all__ = ["build_entry_text", "build_group_text", "build_home_text"]

--- a/src/larvaworld/gui_v2/tabs/home.py
+++ b/src/larvaworld/gui_v2/tabs/home.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from larvaworld.gui_v2.registry_bridge import GuiNavigationModel
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+def build_home_text(
+    model: GuiNavigationModel,
+) -> tuple[str, str, list[tuple[str, str]]]:
+    total_entries = sum(len(lane.entries) for lane in model.lanes)
+    quick_start_modes = len(model.quick_start_modes)
+    ready_entries = sum(
+        1 for entry in model.entry_index.values() if entry.status == "ready"
+    )
+    planned_entries = sum(
+        1 for entry in model.entry_index.values() if entry.status == "planned"
+    )
+
+    blocks = [
+        (
+            "M1 shell objective",
+            "This gui_v2 scaffold establishes a desktop-native shell aligned with the portal "
+            "information architecture while keeping all navigation and content inside the GUI window.",
+        ),
+        (
+            "Shared metadata baseline",
+            f"The shell currently reads {total_entries} lane entries and {quick_start_modes} quick-start "
+            f"modes from the shared portal registry layer. Ready items: {ready_entries}. "
+            f"Under-construction items: {planned_entries}.",
+        ),
+        (
+            "Next implementation pass",
+            "Replace metadata-only content pages with embedded local app surfaces, shell-native views, "
+            "or compatibility wrappers, depending on the per-app render strategy.",
+        ),
+    ]
+
+    return (
+        "gui_v2 desktop shell",
+        "Initial desktop GUI shell aligned with the Larvaworld portal structure.",
+        blocks,
+    )
+
+
+LANE_COLORS: dict[str, str] = {
+    "quick_start": "#f5a142",
+    "simulate": "#b5c2b0",
+    "data": "#b0b4c2",
+    "models": "#c1b0c2",
+}
+
+
+class GuiHomeView(QWidget):
+    def __init__(
+        self,
+        model: GuiNavigationModel,
+        *,
+        on_entry_selected: Callable[[str], None],
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.on_entry_selected = on_entry_selected
+        self.active_mode_id = model.quick_start_modes[0].mode_id
+        self.mode_buttons: dict[str, QPushButton] = {}
+        self.quick_start_cards_layout: QGridLayout | None = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(16)
+
+        layout.addWidget(self._build_quick_start_section())
+
+        for lane in self.model.lanes:
+            layout.addWidget(
+                self._build_lane_section(lane.title, lane.lane_id, list(lane.entries))
+            )
+
+        layout.addStretch(1)
+
+    def _build_quick_start_section(self) -> QWidget:
+        section = QFrame()
+        section.setStyleSheet(
+            "background:#f3f4f6;border:1px solid #d1d5db;border-left:4px solid #f5a142;border-radius:12px;"
+        )
+        outer = QVBoxLayout(section)
+        outer.setContentsMargins(14, 12, 14, 14)
+        outer.setSpacing(12)
+
+        title = QLabel("Quick Start")
+        title.setStyleSheet(
+            "color:#111827; font-size:18px; font-weight:700; border:none;"
+        )
+        outer.addWidget(title)
+
+        mode_row = QHBoxLayout()
+        mode_row.setContentsMargins(0, 0, 0, 0)
+        mode_row.setSpacing(10)
+        for mode in self.model.quick_start_modes:
+            button = QPushButton(mode.title.replace(" mode", ""))
+            button.setCursor(Qt.PointingHandCursor)
+            button.clicked.connect(
+                lambda _checked=False, mode_id=mode.mode_id: self._set_mode(mode_id)
+            )
+            self.mode_buttons[mode.mode_id] = button
+            mode_row.addWidget(button)
+        mode_row.addStretch(1)
+        outer.addLayout(mode_row)
+
+        cards_host = QWidget()
+        self.quick_start_cards_layout = QGridLayout(cards_host)
+        self.quick_start_cards_layout.setContentsMargins(0, 0, 0, 0)
+        self.quick_start_cards_layout.setHorizontalSpacing(14)
+        self.quick_start_cards_layout.setVerticalSpacing(14)
+        outer.addWidget(cards_host)
+
+        self._set_mode(self.active_mode_id)
+        return section
+
+    def _build_lane_section(self, title: str, lane_key: str, entries: list) -> QWidget:
+        section = QFrame()
+        color = LANE_COLORS.get(lane_key, "#d1d5db")
+        section.setStyleSheet(
+            f"background:#ffffff;border:1px solid #d1d5db;border-top:3px solid {color};border-radius:12px;"
+        )
+        outer = QVBoxLayout(section)
+        outer.setContentsMargins(14, 12, 14, 14)
+        outer.setSpacing(12)
+
+        title_label = QLabel(title)
+        title_label.setStyleSheet(
+            "color:#111827; font-size:18px; font-weight:700; border:none;"
+        )
+        outer.addWidget(title_label)
+
+        grid_host = QWidget()
+        grid = QGridLayout(grid_host)
+        grid.setContentsMargins(0, 0, 0, 0)
+        grid.setHorizontalSpacing(14)
+        grid.setVerticalSpacing(14)
+
+        for index, entry in enumerate(entries):
+            grid.addWidget(
+                self._build_entry_card(entry, accent=color), index // 3, index % 3
+            )
+
+        outer.addWidget(grid_host)
+        return section
+
+    def _set_mode(self, mode_id: str) -> None:
+        self.active_mode_id = mode_id
+        for current_mode_id, button in self.mode_buttons.items():
+            mode = next(
+                mode
+                for mode in self.model.quick_start_modes
+                if mode.mode_id == current_mode_id
+            )
+            if current_mode_id == mode_id:
+                button.setStyleSheet(
+                    f"background:{mode.color}; color:#111827; border:1px solid #9ca3af; border-radius:8px; padding:6px 14px; font-weight:600;"
+                )
+            else:
+                button.setStyleSheet(
+                    "background:#ffffff; color:#374151; border:1px solid #d1d5db; border-radius:8px; padding:6px 14px;"
+                )
+
+        if self.quick_start_cards_layout is None:
+            return
+
+        while self.quick_start_cards_layout.count():
+            item = self.quick_start_cards_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+        mode = next(
+            mode for mode in self.model.quick_start_modes if mode.mode_id == mode_id
+        )
+        for index, entry in enumerate(mode.entries):
+            self.quick_start_cards_layout.addWidget(
+                self._build_entry_card(entry, accent=mode.color),
+                index // 3,
+                index % 3,
+            )
+
+    def _build_entry_card(self, entry, *, accent: str) -> QWidget:
+        card = QFrame()
+        card.setStyleSheet(
+            f"background:#ffffff;border:1px solid #d1d5db;border-top:3px solid {accent};border-radius:12px;"
+        )
+        outer = QVBoxLayout(card)
+        outer.setContentsMargins(14, 12, 14, 14)
+        outer.setSpacing(10)
+
+        badges_row = QHBoxLayout()
+        badges_row.setContentsMargins(0, 0, 0, 0)
+        badges_row.setSpacing(6)
+        for badge in entry.badges:
+            badge_label = QLabel(badge)
+            badge_label.setStyleSheet(
+                "background:#f3f4f6;color:#374151;border:1px solid #d1d5db;border-radius:10px;padding:2px 8px;font-size:11px;"
+            )
+            badges_row.addWidget(badge_label)
+        badges_row.addStretch(1)
+        outer.addLayout(badges_row)
+
+        title = QLabel(entry.title)
+        title.setStyleSheet("color:#111827;font-size:16px;font-weight:700;border:none;")
+        title.setWordWrap(True)
+        outer.addWidget(title)
+
+        subtitle = QLabel(entry.subtitle.replace("\n", " "))
+        subtitle.setStyleSheet(
+            "color:#4b5563;font-size:11px;line-height:1.3;border:none;"
+        )
+        subtitle.setWordWrap(True)
+        outer.addWidget(subtitle, 1)
+
+        action_row = QHBoxLayout()
+        action_row.setContentsMargins(0, 0, 0, 0)
+        action_row.setSpacing(8)
+
+        open_button = QPushButton("Open view")
+        open_button.setCursor(Qt.PointingHandCursor)
+        open_button.setStyleSheet(
+            f"background:{accent}; color:#111827; border:1px solid #9ca3af; border-radius:8px; padding:6px 12px; font-weight:600;"
+        )
+        open_button.clicked.connect(
+            lambda _checked=False, entry_id=entry.entry_id: self.on_entry_selected(
+                entry_id
+            )
+        )
+        action_row.addWidget(open_button)
+        action_row.addStretch(1)
+        outer.addLayout(action_row)
+
+        return card
+
+
+def build_home_widget(
+    model: GuiNavigationModel,
+    *,
+    on_entry_selected: Callable[[str], None],
+) -> GuiHomeView:
+    return GuiHomeView(model, on_entry_selected=on_entry_selected)

--- a/src/larvaworld/gui_v2/tabs/placeholder.py
+++ b/src/larvaworld/gui_v2/tabs/placeholder.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from larvaworld.gui_v2.apps.models_environments.environment_builder import (
+    build_environment_builder_text,
+    build_environment_builder_widget,
+)
+from larvaworld.gui_v2.registry_bridge import GuiEntry, GuiNavigationModel
+from PySide6.QtWidgets import QWidget
+
+
+def build_group_text(
+    title: str, description: str, model: GuiNavigationModel
+) -> tuple[str, str, list[tuple[str, str]]]:
+    blocks = [
+        (
+            "Overview",
+            description,
+        ),
+        (
+            "M1 behavior",
+            "Groups currently act as desktop navigation containers. Individual entries open "
+            "in-shell detail pages or placeholders until embedded content is wired.",
+        ),
+        (
+            "Shared-source note",
+            f"The current shell uses {len(model.entry_index)} shared registry entries sourced through a "
+            "temporary bridge. Extraction to a portal-neutral registry remains post-M1 work.",
+        ),
+    ]
+    return title, "Group-level desktop shell view.", blocks
+
+
+def build_entry_text(entry: GuiEntry) -> tuple[str, str, list[tuple[str, str]]]:
+    badges = ", ".join(entry.badges) if entry.badges else "None"
+    docs = entry.docs_url or "No documentation link registered."
+
+    if entry.status == "ready":
+        state_body = (
+            "This entry is marked ready in the shared registry. The gui_v2 shell currently renders "
+            "its metadata in-window while embedded local app integration is implemented incrementally."
+        )
+    else:
+        state_body = (
+            "This entry is not ready yet. The desktop shell exposes it as an in-window placeholder "
+            "so the final GUI structure is already visible without sending the user to an external browser."
+        )
+
+    blocks = [
+        (
+            "Summary",
+            entry.subtitle.replace("\n", " "),
+        ),
+        (
+            "Metadata",
+            f"Lane: {entry.lane_title}\n"
+            f"Kind: {entry.kind}\n"
+            f"Status: {entry.status}\n"
+            f"Level: {entry.level}\n"
+            f"CTA: {entry.cta}\n"
+            f"Badges: {badges}",
+        ),
+        (
+            "Desktop rendering state",
+            state_body,
+        ),
+        (
+            "Documentation",
+            docs,
+        ),
+    ]
+
+    return entry.title, "In-window app detail view.", blocks
+
+
+def build_entry_widget(entry: GuiEntry) -> QWidget | None:
+    if entry.entry_id == "wf.environment_builder":
+        return build_environment_builder_widget(entry)
+    return None

--- a/tests/unit/gui_v2/test_gui_v2_shell.py
+++ b/tests/unit/gui_v2/test_gui_v2_shell.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from larvaworld.gui_v2.registry_bridge import build_navigation_model
+
+
+def test_build_navigation_model_contains_expected_structure() -> None:
+    model = build_navigation_model()
+
+    assert len(model.quick_start_modes) == 3
+    assert len(model.lanes) == 3
+    assert "wf.environment_builder" in model.entry_index
+
+    environment_builder = model.entry_index["wf.environment_builder"]
+    assert environment_builder.title == "Environment Builder"
+    assert environment_builder.lane_key == "models"
+
+
+def test_environment_builder_entry_is_present_in_models_lane() -> None:
+    model = build_navigation_model()
+
+    models_lane = next(lane for lane in model.lanes if lane.lane_id == "models")
+    model_entry_ids = {entry.entry_id for entry in models_lane.entries}
+
+    assert "wf.environment_builder" in model_entry_ids
+
+
+def test_quick_start_modes_expose_expected_labels_and_colors() -> None:
+    model = build_navigation_model()
+
+    quick_start = {mode.mode_id: mode for mode in model.quick_start_modes}
+
+    assert quick_start["user"].title == "User mode"
+    assert quick_start["modeler"].title == "Modeler mode"
+    assert quick_start["experimentalist"].title == "Experimentalist mode"
+
+    assert quick_start["user"].color == "#7c575"
+    assert quick_start["modeler"].color == "#eca548"
+    assert quick_start["experimentalist"].color == "#6cbf6f"


### PR DESCRIPTION
## Description of change

This PR completes the M1 desktop GUI scope and merges `milestone/m1-foundation` into `work/2026q1-deliverables`.

The M1 branch now delivers both the browser-based portal foundation and the initial desktop GUI shell foundation.

Main outcomes included in this merge:
- registry-driven portal architecture and route wiring,
- landing page with workflow lanes, clickable tiles, Quick Start modes, and shared portal shell components,
- rotating GIF showcase banner and notebook launch integration,
- initial browser-based app delivery through the portal,
- first `gui_v2` desktop shell scaffold aligned with the portal structure,
- shared metadata bridge between portal registry data and the new desktop shell,
- lightweight `gui_v2` tests under `tests/unit/gui_v2/`,
- developer workflow improvements including `pre-commit` in development dependencies.

## What was implemented

### Portal foundation
- reusable portal shell with header, footer, shared components, and settings access,
- lane-based workflow tiles and navigation,
- notebook-aware tile actions and isolated notebook workspace handling,
- startup/loading improvements and route warmup behavior,
- first portal-side app groundwork.

### Desktop GUI shell
- new `src/larvaworld/gui_v2/` package,
- `PySide6`-based desktop shell instead of browser-launching behavior,
- collapsible left navigation and portal-aligned home structure,
- shared registry bridge so GUI and portal use the same milestone metadata source,
- dedicated app path scaffold under `gui_v2/apps/`,
- initial `Environment Builder` app path proving the `gui_v2` architecture direction.

## Why this change is needed

This merge establishes the integrated M1 baseline for both UI surfaces:
- browser-based portal,
- desktop GUI shell.

It provides the foundation required for subsequent milestone work without introducing a second disconnected navigation model.

## Verification

Validated through:
- incremental local testing of portal routes and landing interactions,
- notebook launch flow checks,
- gui_v2 runtime launch and shell inspection,
- lightweight gui_v2 unit tests for registry bridge/navigation structure,
- successful `pre-commit` execution on the latest changes.

## Notes

- The detailed M1 history is documented in:
  - `General_use/M1/PR_M1A.md`
  - `General_use/M1/PR_M1B.md`
- The M1 boundary for `gui_v2` is the desktop shell and shared-structure foundation.
- Deeper app parity and full desktop app migration remain M2 work.