### PR TITLE
M3 portal preview refinements and tag-based release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,14 +319,13 @@ jobs:
     environment: release
     concurrency: release
     permissions:
-      id-token: write
-      attestations: write
       contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.sha }}
 
       - name: Setup | Force correct release branch on workflow sha
@@ -350,27 +349,10 @@ jobs:
         with:
           root_options: --noop
 
-      # On main branch: actual PSR + upload to PyPI & GitHub
-      - name: Release and PyPi Upload
+      # On main branch: actual PSR versioning, changelog, commit, and tag.
+      - name: Release
         uses: python-semantic-release/python-semantic-release@v9.8.1
         id: release
         if: github.ref_name == 'master'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v1
-        if: steps.release.outputs.released == 'true'
-        with:
-          subject-path: "dist/*"
-
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: steps.release.outputs.released == 'true'
-
-      - name: Publish package distributions to GitHub Releases
-        uses: python-semantic-release/publish-action@v9.8.1
-        if: steps.release.outputs.released == 'true'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.release.outputs.tag }}
+          github_token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    concurrency: publish-${{ github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry build
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/*"
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/publish-action@v9.8.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}

--- a/src/larvaworld/lib/model/modules/intermitter.py
+++ b/src/larvaworld/lib/model/modules/intermitter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Any
 
+import os
+
 import numpy as np
 import pandas as pd
 import param
@@ -208,7 +210,7 @@ class Intermitter(Timer):
     @property
     def feed_repeated(self) -> bool:
         r = self.feeder_reoccurence_rate if not self.use_EEB else self.EEB
-        return np.random.uniform(0, 1, 1) < r
+        return np.random.random() < r
 
     def alternate_exploreNexploit(
         self, feed_motion: bool = False, on_food: bool = False
@@ -225,11 +227,7 @@ class Intermitter(Timer):
                     self.cur_Nfeeds += 1
                 else:
                     self.trigger_locomotion()
-        elif (
-            on_food
-            and self.cur_Nfeeds is None
-            and np.random.uniform(0, 1, 1) <= self.EEB
-        ):
+        elif on_food and self.cur_Nfeeds is None and np.random.random() <= self.EEB:
             self.cur_Nfeeds = 1
             self.register()
             self.cur_state = "feed"
@@ -307,9 +305,9 @@ class Intermitter(Timer):
             return
         self.register()
         if self.stridechain_generator is not None:
-            self.exp_Nstrides = self.stridechain_generator.sample()
+            self.exp_Nstrides = self.generate_stridechain()
         elif self.run_generator is not None:
-            self.exp_Trun = self.run_generator.sample()
+            self.exp_Trun = self.generate_run()
         self.cur_Nstrides = 0
         self.cur_state = "exec"
         self.ticks = 0
@@ -320,15 +318,16 @@ class Intermitter(Timer):
     def build_dict(self) -> dict[str, Any]:
         cum_t = nam.cum("t")
         d = {}
-        d[cum_t] = self.total_t
+        total_t = self.total_t
+        d[cum_t] = total_t
         d[nam.num("tick")] = int(self.total_ticks)
         for c0 in ["feed", "stride"]:
             c = nam.chain(c0)
-            Nc0, Nc = nam.num([c0, c])
+            Nc0, _ = nam.num([c0, c])
             l = nam.length(c)
             d[l] = [int(ll) for ll in getattr(self, f"{l}s")]
             d[Nc0] = int(sum(d[l]))
-            d[nam.mean(nam.freq(c0))] = d[Nc0] / d[cum_t]
+            d[nam.mean(nam.freq(c0))] = d[Nc0] / total_t if total_t else 0.0
 
         for c in ["feedchain", "stridechain", "pause"]:
             t = nam.dur(c)
@@ -336,7 +335,7 @@ class Intermitter(Timer):
             d[nam.num(c)] = len(d[t])
             cum_chunk_t = nam.cum(t)
             d[cum_chunk_t] = np.sum(d[t])
-            d[nam.dur_ratio(c)] = d[cum_chunk_t] / d[cum_t]
+            d[nam.dur_ratio(c)] = d[cum_chunk_t] / total_t if total_t else 0.0
         return d
 
     def save_dict(
@@ -356,7 +355,7 @@ class Intermitter(Timer):
 
     @property
     def mean_feed_freq(self) -> float:
-        return self.Nfeeds / self.total_t
+        return self.Nfeeds / self.total_t if self.total_t else 0.0
 
 
 class OfflineIntermitter(Intermitter):
@@ -374,7 +373,10 @@ class OfflineIntermitter(Intermitter):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.crawl_ticks = np.round(1 / (self.crawl_freq * self.dt)).astype(int)
-        self.feed_ticks = np.round(1 / (self.feed_freq * self.dt)).astype(int)
+        if self.feed_freq is None:
+            self.feed_ticks = None
+        else:
+            self.feed_ticks = np.round(1 / (self.feed_freq * self.dt)).astype(int)
 
     def step(
         self,
@@ -384,7 +386,12 @@ class OfflineIntermitter(Intermitter):
     ) -> str | None:
         self.count_time()
         if feed_motion is None:
-            feed_motion = self.cur_state == "feed" and self.ticks % self.feed_ticks == 0
+            if self.feed_ticks is None:
+                feed_motion = False
+            else:
+                feed_motion = (
+                    self.cur_state == "feed" and self.ticks % self.feed_ticks == 0
+                )
         if stride_completed is None:
             stride_completed = (
                 self.cur_state == "exec" and self.ticks % self.crawl_ticks == 0
@@ -417,9 +424,6 @@ class BranchIntermitter(Intermitter):
     )
     c = PositiveNumber(default=0.7, doc="The c parameter for the criticality function")
     sigma = PositiveNumber(default=1.0, doc="The ISING branching coef.")
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
     def generate_stridechain(self) -> int:
         return util.exp_bout(
@@ -468,7 +472,7 @@ class FittedIntermitter(OfflineIntermitter):
         super().__init__(**stored_conf)
 
 
-def get_EEB_poly1d(**kws: Any) -> np.poly1d:
+def get_EEB_poly1d(max_dur: float = 60 * 60, **kws: Any) -> np.poly1d:
     """
     Compute polynomial fit of EEB vs mean feeding frequency.
 
@@ -476,6 +480,7 @@ def get_EEB_poly1d(**kws: Any) -> np.poly1d:
     to map feeding frequency back to EEB parameter.
 
     Args:
+        max_dur: Maximum simulation duration (seconds)
         **kws: Intermitter configuration keyword arguments
 
     Returns:
@@ -485,7 +490,6 @@ def get_EEB_poly1d(**kws: Any) -> np.poly1d:
         >>> poly = get_EEB_poly1d(crawl_freq=1.42, feed_freq=2.0, dt=0.1)
         >>> eeb_estimate = poly(0.15)  # For feed_freq=0.15
     """
-    max_dur = 60 * 60
     EEBs = np.arange(0, 1.05, 0.05)
     ms = []
     for EEB in EEBs:
@@ -498,7 +502,10 @@ def get_EEB_poly1d(**kws: Any) -> np.poly1d:
 
 
 def get_EEB_time_fractions(
-    refID: str | None = None, dt: float | None = None, **kwargs: Any
+    refID: str | None = None,
+    dt: float | None = None,
+    max_dur: float = 60 * 60,
+    **kwargs: Any,
 ) -> pd.DataFrame:
     """
     Compute time fractions for behavioral states across EEB range.
@@ -510,6 +517,7 @@ def get_EEB_time_fractions(
     Args:
         refID: Reference dataset ID for intermitter config (optional)
         dt: Time step override (optional)
+        max_dur: Maximum simulation duration (seconds)
         **kwargs: Intermitter configuration if refID not provided
 
     Returns:
@@ -520,12 +528,11 @@ def get_EEB_time_fractions(
         >>> print(df[['EEB', 'crawl ratio', 'pause ratio']])
     """
     if refID is not None:
-        kws = reg.conf.Ref.getRef(refID).intermitter
+        kws = reg.conf.Ref.getRef(refID)["intermitter"]
     else:
         kws = kwargs
     if dt is not None:
         kws["dt"] = dt
-    max_dur = 60 * 60
     rts = {
         f"{q} ratio": nam.dur_ratio(p)
         for p, q in zip(

--- a/src/larvaworld/lib/reg/generators.py
+++ b/src/larvaworld/lib/reg/generators.py
@@ -252,7 +252,9 @@ class SimConfigurationParams(SimConfiguration):
 
         if parameters is not None:
             for k in set(parameters).intersection(set(SimOps().nestedConf)):
-                if k in kwargs:
+                # CLI parsers often pass optional args as None; treat None as
+                # "not provided" so stored experiment defaults are preserved.
+                if k in kwargs and kwargs[k] is not None:
                     parameters[k] = kwargs[k]
                 else:
                     kwargs[k] = parameters[k]

--- a/src/larvaworld/lib/reg/parDB.py
+++ b/src/larvaworld/lib/reg/parDB.py
@@ -1276,13 +1276,24 @@ class ParamRegistry(ParamClass):
         O = output_dict
         if cs is None:
             cs = ["pose"]
+        step_ks = []
+        endpoint_ks = []
+        for c in cs:
+            entry = O[c]
+            if isinstance(entry, dict) or hasattr(entry, "get"):
+                step_ks.append(entry["step"])
+                endpoint_ks.append(entry["endpoint"])
+            else:
+                # Backward-compatible support for entries stored directly as step-key lists
+                step_ks.append(entry)
+                endpoint_ks.append([])
         return AttrDict(
             {
                 "step": self.output_reporters(
-                    ks=SuperList(O[c]["step"] for c in cs).flatten.unique, agents=agents
+                    ks=SuperList(step_ks).flatten.unique, agents=agents
                 ),
                 "end": self.output_reporters(
-                    ks=SuperList(O[c]["endpoint"] for c in cs).flatten.unique,
+                    ks=SuperList(endpoint_ks).flatten.unique,
                     agents=agents,
                 ),
             }

--- a/src/larvaworld/lib/screen/drawing.py
+++ b/src/larvaworld/lib/screen/drawing.py
@@ -89,6 +89,11 @@ class MediaDrawOps(NestedConf):
     save_video = Boolean(False, doc="Whether to save a video.")
     vis_mode = OptionalSelector(objects=["video", "image"], doc="Screen mode.")
     show_display = Boolean(False, doc="Whether to launch the pygame-visualization.")
+    display_every_n_steps = PositiveInteger(
+        1,
+        softmax=20,
+        doc="Live display redraw cadence in simulation steps (display-only mode).",
+    )
 
     @property
     def active(self) -> bool:
@@ -744,16 +749,17 @@ class ScreenManager(ScreenAreaPygame):
             return
 
         self.check(**kwargs)
-        if not self.overlap_mode:
-            self.draw_arena()
-
-        self.draw_agents()
         if self.show_display:
             self.evaluate_input()
             # If display was closed during input handling, abort rendering to avoid surface errors.
             if self.closed or not pygame.display.get_init():
                 return
             self.evaluate_graphs()
+        if self.display_only_mode and not self.should_draw_live_frame:
+            return
+        if not self.overlap_mode:
+            self.draw_arena()
+        self.draw_agents()
         if not self.overlap_mode:
             self._draw_arena(self.tank_color, self.screen_color)
             self.draw_aux()
@@ -764,19 +770,33 @@ class ScreenManager(ScreenAreaPygame):
 
         if self.show_display:
             pygame.display.flip()
-            # Avoid using pixels3d() on the live display surface here.
-            # It returns a view that can keep the SDL surface locked and
-            # has proven unstable in long display+video runs on macOS.
-            image = pygame.surfarray.array3d(self.v)
-            # self._t.tick(self.manager._fps)
-        else:
-            image = pygame.surfarray.array3d(self.v)
+        if self.vid_writer is None and self.img_writer is None:
+            return None
+        # Avoid using pixels3d() on the live display surface here.
+        # It returns a view that can keep the SDL surface locked and
+        # has proven unstable in long display+video runs on macOS.
+        image = pygame.surfarray.array3d(self.v)
         if self.vid_writer:
             self.vid_writer.append_data(np.flipud(np.rot90(image)))
         if self.img_writer:
             self.img_writer.append_data(np.flipud(np.rot90(image)))
             self.img_writer = None
         return image
+
+    @property
+    def display_only_mode(self) -> bool:
+        return (
+            self.show_display
+            and not self.save_video
+            and self.image_mode is None
+            and self.vid_writer is None
+            and self.img_writer is None
+        )
+
+    @property
+    def should_draw_live_frame(self) -> bool:
+        cadence = max(1, int(self.display_every_n_steps))
+        return cadence == 1 or self.model.Nticks % cadence == 0
 
     def initialize(self, **kwargs: Any) -> None:
         """

--- a/src/larvaworld/lib/screen/drawing.py
+++ b/src/larvaworld/lib/screen/drawing.py
@@ -60,6 +60,8 @@ class MediaDrawOps(NestedConf):
         save_video: Whether to save video output
         vis_mode: Screen visualization mode ('video' or 'image')
         show_display: Whether to launch pygame visualization
+        display_every_n_steps: Live display redraw cadence in simulation steps
+            (used only in display-only mode)
 
     Example:
         >>> media_ops = MediaDrawOps(save_video=True, fps=30, video_file='sim')

--- a/src/larvaworld/lib/screen/rendering.py
+++ b/src/larvaworld/lib/screen/rendering.py
@@ -381,27 +381,22 @@ class SimulationClock(PosPixelRel2AreaViewable):
         self.hour = 0
 
     def draw(self, v: Any, **kwargs: Any) -> None:
-        # First pass: set text and render all fonts to get dimensions
+        # Re-anchor every frame to the clock's fixed position. This prevents
+        # cumulative y-drift from repeated rect-center adjustments.
         for k, f in self.text_fonts.items():
+            f.update_font_centre_pos(self)
             t = getattr(self, k)
             if k != "hour":
                 f.set_text(f":{t:02}")
             else:
                 f.set_text(f"{t:02}")
-            # Render text to get rect dimensions
             if f.text_font_r is None:
                 f.render_text()
 
-        # Calculate baseline position using the largest font (hour/minute) as reference
-        # Use hour font as reference since it has the largest font size
         reference_font = self.text_fonts["hour"]
-        baseline_y = reference_font.text_font_r.midbottom[1]
+        baseline_y = self.y + (reference_font.text_font_r.height / 2)
 
-        # Second pass: align all fonts to the same baseline
         for k, f in self.text_fonts.items():
-            # Adjust text_centre y to align baseline
-            # midbottom[1] = center[1] + height/2, so center[1] = midbottom[1] - height/2
-            # We want all midbottoms at the same y, so adjust center accordingly
             adjusted_y = baseline_y - f.text_font_r.height / 2
             f.text_centre = (f.text_centre[0], adjusted_y)
             f.text_font_r.center = f.text_centre

--- a/src/larvaworld/portal/canvas_widgets/__init__.py
+++ b/src/larvaworld/portal/canvas_widgets/__init__.py
@@ -7,6 +7,7 @@ from .environment_models import (
     CanvasObject,
     CanvasObjectType,
     EnvironmentCanvasState,
+    LarvaPreviewFrame,
 )
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "CanvasObjectType",
     "EnvironmentCanvas",
     "EnvironmentCanvasState",
+    "LarvaPreviewFrame",
     "env_params_to_canvas_state",
 ]

--- a/src/larvaworld/portal/canvas_widgets/__init__.py
+++ b/src/larvaworld/portal/canvas_widgets/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from .environment_canvas import EnvironmentCanvas
+from .environment_mapping import env_params_to_canvas_state
+from .environment_models import (
+    CanvasArena,
+    CanvasObject,
+    CanvasObjectType,
+    EnvironmentCanvasState,
+)
+
+__all__ = [
+    "CanvasArena",
+    "CanvasObject",
+    "CanvasObjectType",
+    "EnvironmentCanvas",
+    "EnvironmentCanvasState",
+    "env_params_to_canvas_state",
+]

--- a/src/larvaworld/portal/canvas_widgets/environment_canvas.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_canvas.py
@@ -1,0 +1,1518 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Iterable
+
+import numpy as np
+import panel as pn
+from bokeh.colors import named as named_colors
+from bokeh.models import ColumnDataSource, WheelZoomTool
+from bokeh.plotting import figure
+
+from larvaworld.lib.param.xy_distro import Spatial_Distro
+
+from .environment_models import CanvasArena, CanvasObject, EnvironmentCanvasState
+
+
+LANE_MODELS_COLOR_DARK = "#5a4760"
+DEFAULT_SOURCE_COLOR = "#4caf50"
+DEFAULT_LARVA_COLOR = "#2f4858"
+HIGHLIGHT_COLOR = "#f97316"
+ENV_CANVAS_WIDTH = 760
+ENV_CANVAS_HEIGHT = 620
+ENV_CANVAS_Y_HALF_RANGE = 0.30
+ENV_CANVAS_X_HALF_RANGE = ENV_CANVAS_Y_HALF_RANGE * (
+    ENV_CANVAS_WIDTH / ENV_CANVAS_HEIGHT
+)
+
+
+def _empty(keys: Iterable[str]) -> dict[str, list[Any]]:
+    return {key: [] for key in keys}
+
+
+def _rows_to_data(
+    rows: Iterable[dict[str, Any]], keys: Iterable[str]
+) -> dict[str, list[Any]]:
+    data = _empty(keys)
+    for row in rows:
+        for key in data:
+            data[key].append(row.get(key))
+    return data
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None:
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _mix_hex_colors(color_a: Any, color_b: Any, ratio: float) -> str:
+    ratio = max(0.0, min(1.0, float(ratio)))
+
+    def _parse(color: Any) -> tuple[int, int, int]:
+        if isinstance(color, (list, tuple)) and len(color) >= 3:
+            try:
+                channels = [float(component) for component in color[:3]]
+            except (TypeError, ValueError):
+                return (76, 175, 80)
+            if all(0.0 <= channel <= 1.0 for channel in channels):
+                return tuple(int(round(channel * 255)) for channel in channels)
+            return tuple(
+                int(round(max(0.0, min(255.0, channel)))) for channel in channels
+            )
+        raw = str(color).strip()
+        if not raw:
+            return (76, 175, 80)
+        if not raw.startswith("#"):
+            named = getattr(named_colors, raw.lower().replace(" ", ""), None)
+            if named is not None:
+                rgb = named.to_rgb()
+                return (int(rgb.r), int(rgb.g), int(rgb.b))
+        cleaned = raw.lstrip("#")
+        if len(cleaned) == 3:
+            cleaned = "".join(char * 2 for char in cleaned)
+        if len(cleaned) != 6:
+            return (76, 175, 80)
+        try:
+            return tuple(int(cleaned[idx : idx + 2], 16) for idx in (0, 2, 4))
+        except ValueError:
+            return (76, 175, 80)
+
+    rgb_a = _parse(color_a)
+    rgb_b = _parse(color_b)
+    mixed = tuple(
+        int(round((1.0 - ratio) * component_a + ratio * component_b))
+        for component_a, component_b in zip(rgb_a, rgb_b)
+    )
+    return "#{:02x}{:02x}{:02x}".format(*mixed)
+
+
+def _source_visual_state(
+    *,
+    amount: float | None,
+    color: str | None,
+) -> tuple[str, str, float, float, float]:
+    base_color = str(color or DEFAULT_SOURCE_COLOR)
+    has_food = amount is not None and _safe_float(amount) > 0
+    fill_color = _mix_hex_colors(base_color, "#ffffff", 0.0 if has_food else 0.68)
+    line_color = _mix_hex_colors(base_color, "#111111", 0.08 if has_food else 0.02)
+    return (
+        fill_color,
+        line_color,
+        0.94 if has_food else 0.34,
+        0.98 if has_food else 0.58,
+        2.6 if has_food else 1.6,
+    )
+
+
+def _stable_preview_seed(*parts: object) -> int:
+    seed = 2166136261
+    for part in parts:
+        for char in str(part):
+            seed ^= ord(char)
+            seed = (seed * 16777619) & 0xFFFFFFFF
+    return seed
+
+
+def _normalize_group_shape(value: str | None) -> str:
+    shape = str(value or "circle").strip().lower()
+    if shape in {"oval", "ellipse", "elliptic"}:
+        return "oval"
+    if shape in {"rect", "rectangle", "square"}:
+        return "rect"
+    return "circle"
+
+
+def _rotate_point(x: float, y: float, angle: float) -> tuple[float, float]:
+    cos_a = math.cos(angle)
+    sin_a = math.sin(angle)
+    return (x * cos_a - y * sin_a, x * sin_a + y * cos_a)
+
+
+def _build_odor_layers(
+    *,
+    x: float | None,
+    y: float | None,
+    source_radius: float | None,
+    odor_id: str | None,
+    odor_intensity: float | None,
+    odor_spread: float | None,
+    color: str | None,
+    source_id: str | None,
+) -> list[dict[str, object]]:
+    if x is None or y is None or not odor_id:
+        return []
+    if odor_intensity is None or odor_spread is None:
+        return []
+    spread = _safe_float(odor_spread)
+    intensity = _safe_float(odor_intensity)
+    if spread <= 0 or intensity <= 0:
+        return []
+
+    intensity_scale = min(1.0, 0.35 + 0.18 * intensity)
+    source_r = max(_safe_float(source_radius), 0.002)
+    aura_color = _mix_hex_colors(str(color or DEFAULT_SOURCE_COLOR), "#ffffff", 0.2)
+    sigmas = [0.45, 0.9, 1.4, 2.0, 2.8, 3.8]
+    alphas = [0.18, 0.13, 0.09, 0.055, 0.03, 0.014]
+    rows: list[dict[str, object]] = []
+    for sigma, alpha in zip(sigmas, alphas):
+        rows.append(
+            {
+                "x": float(x),
+                "y": float(y),
+                "r": source_r + spread * sigma,
+                "color": aura_color,
+                "fill_alpha": alpha * intensity_scale,
+                "id": str(source_id or ""),
+            }
+        )
+    return rows
+
+
+def _build_odor_peak(
+    *,
+    x: float | None,
+    y: float | None,
+    source_radius: float | None,
+    odor_id: str | None,
+    odor_intensity: float | None,
+    odor_spread: float | None,
+    color: str | None,
+    source_id: str | None,
+) -> dict[str, object] | None:
+    if x is None or y is None or not odor_id:
+        return None
+    if odor_intensity is None or odor_spread is None:
+        return None
+    spread = _safe_float(odor_spread)
+    intensity = _safe_float(odor_intensity)
+    if spread <= 0 or intensity <= 0:
+        return None
+
+    source_r = max(_safe_float(source_radius), 0.002)
+    peak_radius = max(source_r * 0.42, min(spread * 0.3, source_r * 0.72))
+    peak_color = _mix_hex_colors(str(color or DEFAULT_SOURCE_COLOR), "#ffffff", 0.08)
+    return {
+        "x": float(x),
+        "y": float(y),
+        "r": peak_radius,
+        "color": peak_color,
+        "fill_alpha": min(0.72, 0.44 + 0.1 * intensity),
+        "id": str(source_id or ""),
+    }
+
+
+class EnvironmentCanvas:
+    """Reusable read-only Bokeh canvas for portal environment previews."""
+
+    def __init__(
+        self,
+        *,
+        width: int = ENV_CANVAS_WIDTH,
+        height: int = ENV_CANVAS_HEIGHT,
+        editable: bool = False,
+    ) -> None:
+        self.width = int(width)
+        self.height = int(height)
+        self.editable = bool(editable)
+        self._state: EnvironmentCanvasState | None = None
+        self._arena = CanvasArena("rectangular", (0.2, 0.2))
+
+        self.arena_source = ColumnDataSource({"x": [], "y": [], "w": [], "h": []})
+        self.food_grid_overlay_source = ColumnDataSource(
+            {"x": [], "y": [], "w": [], "h": [], "color": [], "fill_alpha": []}
+        )
+        self.food_grid_cell_source = ColumnDataSource(
+            _empty(
+                [
+                    "x",
+                    "y",
+                    "w",
+                    "h",
+                    "fill_color",
+                    "line_color",
+                    "fill_alpha",
+                    "line_alpha",
+                    "line_width",
+                ]
+            )
+        )
+        self.thermoscape_aura_source = ColumnDataSource(
+            _empty(["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"])
+        )
+        self.thermoscape_marker_source = ColumnDataSource(
+            _empty(["x", "y", "color", "size", "id"])
+        )
+        self.windscape_segment_source = ColumnDataSource(
+            _empty(["x0", "y0", "x1", "y1", "color", "line_alpha"])
+        )
+        self.windscape_head_source = ColumnDataSource(
+            _empty(["x", "y", "angle", "color", "size"])
+        )
+        self.odorscape_contour_source = ColumnDataSource(
+            _empty(["x", "y", "r", "color", "line_alpha", "line_width", "id"])
+        )
+        self.odor_layer_source = ColumnDataSource(
+            _empty(["x", "y", "r", "color", "fill_alpha", "id"])
+        )
+        self.odor_peak_source = ColumnDataSource(
+            _empty(["x", "y", "r", "color", "fill_alpha", "id"])
+        )
+        self.food_source = ColumnDataSource(
+            _empty(
+                [
+                    "x",
+                    "y",
+                    "r",
+                    "fill_color",
+                    "line_color",
+                    "id",
+                    "fill_alpha",
+                    "line_alpha",
+                    "line_width",
+                ]
+            )
+        )
+        self.food_highlight_source = ColumnDataSource(
+            {"x": [], "y": [], "r": [], "color": []}
+        )
+        self.source_group_circle_source = ColumnDataSource(
+            _empty(["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"])
+        )
+        self.source_group_ellipse_source = ColumnDataSource(
+            _empty(["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"])
+        )
+        self.source_group_rect_source = ColumnDataSource(
+            _empty(["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"])
+        )
+        self.source_group_member_source = ColumnDataSource(
+            _empty(
+                [
+                    "x",
+                    "y",
+                    "r",
+                    "fill_color",
+                    "line_color",
+                    "fill_alpha",
+                    "line_alpha",
+                    "line_width",
+                    "parent_id",
+                ]
+            )
+        )
+        self.source_group_circle_highlight_source = ColumnDataSource(
+            {"x": [], "y": [], "r": [], "color": []}
+        )
+        self.source_group_ellipse_highlight_source = ColumnDataSource(
+            {"x": [], "y": [], "w": [], "h": [], "color": []}
+        )
+        self.source_group_rect_highlight_source = ColumnDataSource(
+            {"x": [], "y": [], "w": [], "h": [], "color": []}
+        )
+        self.border_source = ColumnDataSource(
+            _empty(["x0", "y0", "x1", "y1", "w", "color", "id"])
+        )
+        self.border_highlight_source = ColumnDataSource(
+            {"x0": [], "y0": [], "x1": [], "y1": [], "w": [], "color": []}
+        )
+        self.larva_group_circle_source = ColumnDataSource(
+            _empty(["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"])
+        )
+        self.larva_group_ellipse_source = ColumnDataSource(
+            _empty(["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"])
+        )
+        self.larva_group_rect_source = ColumnDataSource(
+            _empty(["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"])
+        )
+        self.larva_group_member_source = ColumnDataSource(
+            _empty(
+                [
+                    "x",
+                    "y",
+                    "r",
+                    "fill_color",
+                    "line_color",
+                    "fill_alpha",
+                    "line_alpha",
+                    "line_width",
+                    "parent_id",
+                ]
+            )
+        )
+        self.larva_group_circle_highlight_source = ColumnDataSource(
+            {"x": [], "y": [], "r": [], "color": []}
+        )
+        self.larva_group_ellipse_highlight_source = ColumnDataSource(
+            {"x": [], "y": [], "w": [], "h": [], "color": []}
+        )
+        self.larva_group_rect_highlight_source = ColumnDataSource(
+            {"x": [], "y": [], "w": [], "h": [], "color": []}
+        )
+
+        self.fig = figure(
+            title="Environment canvas",
+            x_range=(-ENV_CANVAS_X_HALF_RANGE, ENV_CANVAS_X_HALF_RANGE),
+            y_range=(-ENV_CANVAS_Y_HALF_RANGE, ENV_CANVAS_Y_HALF_RANGE),
+            match_aspect=True,
+            width=self.width,
+            height=self.height,
+            tools="pan,wheel_zoom,reset,save",
+            active_scroll="wheel_zoom",
+            toolbar_location="right",
+        )
+        wheel_zoom = self.fig.select_one(WheelZoomTool)
+        if wheel_zoom is not None:
+            wheel_zoom.dimensions = "both"
+            wheel_zoom.zoom_on_axis = False
+        self.fig.background_fill_color = "#ffffff"
+        self.fig.border_fill_color = "#fafafa"
+        self.fig.xaxis.axis_label = "X (m)"
+        self.fig.yaxis.axis_label = "Y (m)"
+
+        self._arena_rect_renderer = self.fig.rect(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.arena_source,
+            line_color=LANE_MODELS_COLOR_DARK,
+            line_width=3,
+            fill_alpha=0.0,
+            visible=True,
+        )
+        self._food_grid_rect_renderer = self.fig.rect(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.food_grid_overlay_source,
+            line_color=None,
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            visible=True,
+        )
+        self._arena_circle_renderer = self.fig.ellipse(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.arena_source,
+            line_color=LANE_MODELS_COLOR_DARK,
+            line_width=3,
+            fill_alpha=0.0,
+            visible=False,
+        )
+        self._food_grid_circle_renderer = self.fig.ellipse(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.food_grid_overlay_source,
+            line_color=None,
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            visible=False,
+        )
+        self.fig.rect(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.food_grid_cell_source,
+            line_color="line_color",
+            line_alpha="line_alpha",
+            line_width="line_width",
+            fill_color="fill_color",
+            fill_alpha="fill_alpha",
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.thermoscape_aura_source,
+            line_color="color",
+            line_alpha="line_alpha",
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            line_width=1,
+            legend_label="Thermoscape",
+        )
+        self.fig.segment(
+            x0="x0",
+            y0="y0",
+            x1="x1",
+            y1="y1",
+            source=self.windscape_segment_source,
+            line_color="color",
+            line_alpha="line_alpha",
+            line_width=2,
+            legend_label="Windscape",
+        )
+        self.fig.scatter(
+            x="x",
+            y="y",
+            source=self.windscape_head_source,
+            marker="triangle",
+            angle="angle",
+            size="size",
+            line_color="color",
+            fill_color="color",
+            fill_alpha=0.75,
+            line_alpha=0.85,
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.odorscape_contour_source,
+            line_color="color",
+            line_alpha="line_alpha",
+            line_width="line_width",
+            fill_alpha=0.0,
+            legend_label="Odorscape",
+        )
+        self.fig.scatter(
+            x="x",
+            y="y",
+            source=self.thermoscape_marker_source,
+            marker="diamond",
+            size="size",
+            line_color="color",
+            fill_color="color",
+            fill_alpha=0.9,
+            line_alpha=0.95,
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.odor_layer_source,
+            line_color=None,
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            legend_label="Odor aura",
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.food_source,
+            line_color="line_color",
+            fill_color="fill_color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_width="line_width",
+            legend_label="Source units",
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.odor_peak_source,
+            line_color=None,
+            fill_color="color",
+            fill_alpha="fill_alpha",
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.food_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.source_group_circle_source,
+            line_color="color",
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_width=2,
+            legend_label="Source groups",
+        )
+        self.fig.ellipse(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.source_group_ellipse_source,
+            line_color="color",
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_width=2,
+        )
+        self.fig.rect(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.source_group_rect_source,
+            line_color="color",
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_width=2,
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.source_group_member_source,
+            line_color="line_color",
+            fill_color="fill_color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_width="line_width",
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.source_group_circle_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.ellipse(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.source_group_ellipse_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.rect(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.source_group_rect_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.segment(
+            x0="x0",
+            y0="y0",
+            x1="x1",
+            y1="y1",
+            source=self.border_source,
+            line_color="color",
+            line_width="w",
+            legend_label="Borders",
+        )
+        self.fig.segment(
+            x0="x0",
+            y0="y0",
+            x1="x1",
+            y1="y1",
+            source=self.border_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            line_width="w",
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.larva_group_circle_source,
+            line_color="color",
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_dash="dashed",
+            line_width=2,
+            legend_label="Larva groups",
+        )
+        self.fig.ellipse(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.larva_group_ellipse_source,
+            line_color="color",
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_dash="dashed",
+            line_width=2,
+        )
+        self.fig.rect(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.larva_group_rect_source,
+            line_color="color",
+            fill_color="color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_dash="dashed",
+            line_width=2,
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.larva_group_member_source,
+            line_color="line_color",
+            fill_color="fill_color",
+            fill_alpha="fill_alpha",
+            line_alpha="line_alpha",
+            line_width="line_width",
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.larva_group_circle_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.ellipse(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.larva_group_ellipse_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.rect(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.larva_group_rect_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.legend.click_policy = "hide"
+        self.fig.legend.location = "top_left"
+
+        self._pane = pn.pane.Bokeh(self.fig, sizing_mode="stretch_width")
+
+    def view(self) -> pn.viewable.Viewable:
+        return self._pane
+
+    def clear(self) -> None:
+        self.arena_source.data = {"x": [], "y": [], "w": [], "h": []}
+        self.food_grid_overlay_source.data = {
+            "x": [],
+            "y": [],
+            "w": [],
+            "h": [],
+            "color": [],
+            "fill_alpha": [],
+        }
+        self.food_grid_cell_source.data = _empty(
+            [
+                "x",
+                "y",
+                "w",
+                "h",
+                "fill_color",
+                "line_color",
+                "fill_alpha",
+                "line_alpha",
+                "line_width",
+            ]
+        )
+        self.thermoscape_aura_source.data = _empty(
+            ["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.thermoscape_marker_source.data = _empty(["x", "y", "color", "size", "id"])
+        self.windscape_segment_source.data = _empty(
+            ["x0", "y0", "x1", "y1", "color", "line_alpha"]
+        )
+        self.windscape_head_source.data = _empty(["x", "y", "angle", "color", "size"])
+        self.odorscape_contour_source.data = _empty(
+            ["x", "y", "r", "color", "line_alpha", "line_width", "id"]
+        )
+        self.odor_layer_source.data = _empty(
+            ["x", "y", "r", "color", "fill_alpha", "id"]
+        )
+        self.odor_peak_source.data = _empty(
+            ["x", "y", "r", "color", "fill_alpha", "id"]
+        )
+        self.food_source.data = _empty(
+            [
+                "x",
+                "y",
+                "r",
+                "fill_color",
+                "line_color",
+                "id",
+                "fill_alpha",
+                "line_alpha",
+                "line_width",
+            ]
+        )
+        self.source_group_circle_source.data = _empty(
+            ["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.source_group_ellipse_source.data = _empty(
+            ["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.source_group_rect_source.data = _empty(
+            ["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.source_group_member_source.data = _empty(
+            [
+                "x",
+                "y",
+                "r",
+                "fill_color",
+                "line_color",
+                "fill_alpha",
+                "line_alpha",
+                "line_width",
+                "parent_id",
+            ]
+        )
+        self.border_source.data = _empty(["x0", "y0", "x1", "y1", "w", "color", "id"])
+        self.larva_group_circle_source.data = _empty(
+            ["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.larva_group_ellipse_source.data = _empty(
+            ["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.larva_group_rect_source.data = _empty(
+            ["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.larva_group_member_source.data = _empty(
+            [
+                "x",
+                "y",
+                "r",
+                "fill_color",
+                "line_color",
+                "fill_alpha",
+                "line_alpha",
+                "line_width",
+                "parent_id",
+            ]
+        )
+        self.set_selected_object(None)
+        self._state = None
+
+    def set_state(self, state: EnvironmentCanvasState) -> None:
+        self._arena = state.arena
+        self.clear()
+        self._state = state
+        self._apply_arena(state.arena)
+        self._apply_food_grid(state.food_grid)
+        self._apply_scapes(state)
+        self._apply_objects(state.objects)
+
+    def set_selected_object(self, object_id: str | None) -> None:
+        self.food_highlight_source.data = {"x": [], "y": [], "r": [], "color": []}
+        self.source_group_circle_highlight_source.data = {
+            "x": [],
+            "y": [],
+            "r": [],
+            "color": [],
+        }
+        self.source_group_ellipse_highlight_source.data = {
+            "x": [],
+            "y": [],
+            "w": [],
+            "h": [],
+            "color": [],
+        }
+        self.source_group_rect_highlight_source.data = {
+            "x": [],
+            "y": [],
+            "w": [],
+            "h": [],
+            "color": [],
+        }
+        self.border_highlight_source.data = {
+            "x0": [],
+            "y0": [],
+            "x1": [],
+            "y1": [],
+            "w": [],
+            "color": [],
+        }
+        self.larva_group_circle_highlight_source.data = {
+            "x": [],
+            "y": [],
+            "r": [],
+            "color": [],
+        }
+        self.larva_group_ellipse_highlight_source.data = {
+            "x": [],
+            "y": [],
+            "w": [],
+            "h": [],
+            "color": [],
+        }
+        self.larva_group_rect_highlight_source.data = {
+            "x": [],
+            "y": [],
+            "w": [],
+            "h": [],
+            "color": [],
+        }
+        if not object_id or self._state is None:
+            return
+        obj = next(
+            (
+                candidate
+                for candidate in self._state.objects
+                if candidate.object_id == object_id
+            ),
+            None,
+        )
+        if obj is None:
+            return
+        if obj.object_type == "source_unit" and obj.x is not None and obj.y is not None:
+            self.food_highlight_source.data = {
+                "x": [obj.x],
+                "y": [obj.y],
+                "r": [max(_safe_float(obj.radius, 0.003) * 1.35, 0.004)],
+                "color": [HIGHLIGHT_COLOR],
+            }
+        elif obj.object_type == "source_group":
+            self._set_group_highlight(
+                obj,
+                self.source_group_circle_highlight_source,
+                self.source_group_ellipse_highlight_source,
+                self.source_group_rect_highlight_source,
+            )
+        elif obj.object_type == "larva_group":
+            self._set_group_highlight(
+                obj,
+                self.larva_group_circle_highlight_source,
+                self.larva_group_ellipse_highlight_source,
+                self.larva_group_rect_highlight_source,
+            )
+        elif obj.object_type == "border_segment":
+            self.border_highlight_source.data = {
+                "x0": [obj.x],
+                "y0": [obj.y],
+                "x1": [obj.x2],
+                "y1": [obj.y2],
+                "w": [max(4, int(_safe_float(obj.width, 0.001) * 1500) + 2)],
+                "color": [HIGHLIGHT_COLOR],
+            }
+
+    def _arena_dimensions(self) -> tuple[float, float]:
+        dims = self._arena.dims
+        width = abs(_safe_float(dims[0] if len(dims) > 0 else 0.2, 0.2))
+        height = abs(_safe_float(dims[1] if len(dims) > 1 else width, width))
+        if width <= 0:
+            width = 0.2
+        if height <= 0:
+            height = width
+        return width, height
+
+    def _apply_arena(self, arena: CanvasArena) -> None:
+        self._arena = arena
+        width, height = self._arena_dimensions()
+        self.arena_source.data = {"x": [0.0], "y": [0.0], "w": [width], "h": [height]}
+        is_circular = str(arena.geometry).lower().startswith("circ")
+        self._arena_circle_renderer.visible = is_circular
+        self._food_grid_circle_renderer.visible = is_circular
+        self._arena_rect_renderer.visible = not is_circular
+        self._food_grid_rect_renderer.visible = not is_circular
+        pad_scale = 1.24
+        required_x_span = width * pad_scale
+        required_y_span = height * pad_scale
+        canvas_ratio = self.width / self.height
+        if required_x_span / required_y_span < canvas_ratio:
+            y_span = required_y_span
+            x_span = y_span * canvas_ratio
+        else:
+            x_span = required_x_span
+            y_span = x_span / canvas_ratio
+        self.fig.x_range.start = -x_span / 2
+        self.fig.x_range.end = x_span / 2
+        self.fig.y_range.start = -y_span / 2
+        self.fig.y_range.end = y_span / 2
+
+    def _apply_food_grid(self, food_grid: dict[str, Any] | None) -> None:
+        if not isinstance(food_grid, dict):
+            return
+        width, height = self._arena_dimensions()
+        color = str(food_grid.get("color") or DEFAULT_SOURCE_COLOR)
+        self.food_grid_overlay_source.data = {
+            "x": [0.0],
+            "y": [0.0],
+            "w": [width],
+            "h": [height],
+            "color": [color],
+            "fill_alpha": [0.08],
+        }
+        grid_dims = food_grid.get("grid_dims", (0, 0))
+        try:
+            nx = max(int(grid_dims[0]), 1)
+            ny = max(int(grid_dims[1]), 1)
+        except Exception:
+            return
+        cell_w = width / nx
+        cell_h = height / ny
+        fill_color = _mix_hex_colors(color, "#ffffff", 0.32)
+        line_color = _mix_hex_colors(color, "#111111", 0.20)
+        xs = np.linspace(-width / 2 + cell_w / 2, width / 2 - cell_w / 2, nx)
+        ys = np.linspace(-height / 2 + cell_h / 2, height / 2 - cell_h / 2, ny)
+        rows: list[dict[str, Any]] = []
+        for center_x in xs:
+            for center_y in ys:
+                if str(self._arena.geometry).lower().startswith("circ"):
+                    nx_ellipse = float(center_x) / (width / 2)
+                    ny_ellipse = float(center_y) / (height / 2)
+                    if (nx_ellipse * nx_ellipse + ny_ellipse * ny_ellipse) > 1.0:
+                        continue
+                rows.append(
+                    {
+                        "x": float(center_x),
+                        "y": float(center_y),
+                        "w": float(cell_w),
+                        "h": float(cell_h),
+                        "fill_color": fill_color,
+                        "line_color": line_color,
+                        "fill_alpha": 0.10,
+                        "line_alpha": 0.42,
+                        "line_width": 0.9,
+                    }
+                )
+        self.food_grid_cell_source.data = _rows_to_data(
+            rows,
+            [
+                "x",
+                "y",
+                "w",
+                "h",
+                "fill_color",
+                "line_color",
+                "fill_alpha",
+                "line_alpha",
+                "line_width",
+            ],
+        )
+
+    def _apply_scapes(self, state: EnvironmentCanvasState) -> None:
+        try:
+            self._apply_odorscape(state.odorscape, state.objects)
+        except Exception:
+            self.odorscape_contour_source.data = _empty(
+                ["x", "y", "r", "color", "line_alpha", "line_width", "id"]
+            )
+        try:
+            self._apply_windscape(state.windscape)
+        except Exception:
+            self.windscape_segment_source.data = _empty(
+                ["x0", "y0", "x1", "y1", "color", "line_alpha"]
+            )
+            self.windscape_head_source.data = _empty(
+                ["x", "y", "angle", "color", "size"]
+            )
+        try:
+            self._apply_thermoscape(state.thermoscape)
+        except Exception:
+            self.thermoscape_aura_source.data = _empty(
+                ["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"]
+            )
+            self.thermoscape_marker_source.data = _empty(
+                ["x", "y", "color", "size", "id"]
+            )
+
+    def _apply_odorscape(
+        self, odorscape: dict[str, Any] | None, objects: tuple[CanvasObject, ...]
+    ) -> None:
+        if not isinstance(odorscape, dict):
+            return
+        color = str(odorscape.get("color") or DEFAULT_SOURCE_COLOR)
+        mode = str(
+            odorscape.get("odorscape") or odorscape.get("unique_id") or "Gaussian"
+        )
+        line_alpha_scale = {"Analytical": 0.42, "Gaussian": 0.32, "Diffusion": 0.24}
+        mults = [0.5, 1.0, 1.5, 2.2]
+        rows: list[dict[str, Any]] = []
+        for obj in objects:
+            if obj.object_type not in {"source_unit", "source_group"}:
+                continue
+            if obj.x is None or obj.y is None or not obj.odor_id:
+                continue
+            spread = _safe_float(obj.odor_spread)
+            intensity = _safe_float(obj.odor_intensity)
+            if spread <= 0 or intensity <= 0:
+                continue
+            source_r = max(_safe_float(obj.radius, 0.003), 0.002)
+            for index, mult in enumerate(mults):
+                rows.append(
+                    {
+                        "x": float(obj.x),
+                        "y": float(obj.y),
+                        "r": source_r + spread * mult,
+                        "color": color,
+                        "line_alpha": max(
+                            0.08,
+                            line_alpha_scale.get(mode, 0.3) - index * 0.07,
+                        ),
+                        "line_width": max(1.0, 2.2 - index * 0.35),
+                        "id": str(obj.object_id),
+                    }
+                )
+        self.odorscape_contour_source.data = _rows_to_data(
+            rows, ["x", "y", "r", "color", "line_alpha", "line_width", "id"]
+        )
+
+    def _apply_windscape(self, windscape: dict[str, Any] | None) -> None:
+        if not isinstance(windscape, dict):
+            return
+        speed = _safe_float(windscape.get("wind_speed"), 0.0)
+        if speed <= 0:
+            return
+        width, height = self._arena_dimensions()
+        d = max(width, height) * 0.48
+        n = 9
+        ds = d / n * math.sqrt(2)
+        direction_rad = _safe_float(windscape.get("wind_direction"), math.pi)
+        angle = -direction_rad
+        color = str(windscape.get("color") or "#ff0000")
+        segment_rows = []
+        head_rows = []
+        for i in range(n):
+            y_offset = (i - n / 2) * ds
+            p0 = _rotate_point(-d, y_offset, angle)
+            p1 = _rotate_point(d, y_offset, angle)
+            segment_rows.append(
+                {
+                    "x0": p0[0],
+                    "y0": p0[1],
+                    "x1": p1[0],
+                    "y1": p1[1],
+                    "color": color,
+                    "line_alpha": min(0.9, 0.25 + speed / 80.0),
+                }
+            )
+            head_rows.append(
+                {
+                    "x": p1[0],
+                    "y": p1[1],
+                    "angle": direction_rad - math.pi / 2.0,
+                    "color": color,
+                    "size": min(14.0, 8.0 + speed / 8.0),
+                }
+            )
+        self.windscape_segment_source.data = _rows_to_data(
+            segment_rows, ["x0", "y0", "x1", "y1", "color", "line_alpha"]
+        )
+        self.windscape_head_source.data = _rows_to_data(
+            head_rows, ["x", "y", "angle", "color", "size"]
+        )
+
+    def _apply_thermoscape(self, thermoscape: dict[str, Any] | None) -> None:
+        if not isinstance(thermoscape, dict):
+            return
+        spread = max(_safe_float(thermoscape.get("spread"), 0.1), 0.001)
+        source_map = thermoscape.get("thermo_sources") or {}
+        dtemp_map = thermoscape.get("thermo_source_dTemps") or {}
+        source_rows = thermoscape.get("sources") or []
+        records: list[dict[str, Any]] = []
+        if isinstance(source_map, dict):
+            for source_id, position in source_map.items():
+                try:
+                    x, y = position
+                except Exception:
+                    continue
+                dtemp = (
+                    dtemp_map.get(source_id, 0.0)
+                    if isinstance(dtemp_map, dict)
+                    else 0.0
+                )
+                records.append(
+                    {
+                        "id": str(source_id),
+                        "x": _safe_float(x),
+                        "y": _safe_float(y),
+                        "dTemp": dtemp,
+                    }
+                )
+        if isinstance(source_rows, list):
+            for row in source_rows:
+                if isinstance(row, dict):
+                    records.append(row)
+        aura_rows: list[dict[str, Any]] = []
+        marker_rows: list[dict[str, Any]] = []
+        for row in records:
+            source_id = str(row.get("id") or "").strip()
+            if not source_id:
+                source_id = "thermal_source"
+            x = _safe_float(row.get("x"), 0.0)
+            y = _safe_float(row.get("y"), 0.0)
+            dtemp = _safe_float(row.get("dTemp"), _safe_float(row.get("dtemp"), 0.0))
+            color = "#d94841" if dtemp >= 0 else "#356ae6"
+            marker_rows.append(
+                {
+                    "x": x,
+                    "y": y,
+                    "color": color,
+                    "size": min(18.0, 10.0 + abs(dtemp) * 0.8),
+                    "id": source_id,
+                }
+            )
+            for mult, alpha in zip([0.45, 0.9, 1.5], [0.18, 0.10, 0.05]):
+                aura_rows.append(
+                    {
+                        "x": x,
+                        "y": y,
+                        "r": spread * mult,
+                        "color": color,
+                        "fill_alpha": alpha,
+                        "line_alpha": max(0.12, alpha + 0.03),
+                        "id": source_id,
+                    }
+                )
+        self.thermoscape_aura_source.data = _rows_to_data(
+            aura_rows, ["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.thermoscape_marker_source.data = _rows_to_data(
+            marker_rows, ["x", "y", "color", "size", "id"]
+        )
+
+    def _apply_objects(self, objects: tuple[CanvasObject, ...]) -> None:
+        food_rows: list[dict[str, Any]] = []
+        odor_rows: list[dict[str, Any]] = []
+        peak_rows: list[dict[str, Any]] = []
+        circle_rows: list[dict[str, Any]] = []
+        ellipse_rows: list[dict[str, Any]] = []
+        rect_rows: list[dict[str, Any]] = []
+        member_rows: list[dict[str, Any]] = []
+        border_rows: list[dict[str, Any]] = []
+        larva_circle_rows: list[dict[str, Any]] = []
+        larva_ellipse_rows: list[dict[str, Any]] = []
+        larva_rect_rows: list[dict[str, Any]] = []
+        larva_member_rows: list[dict[str, Any]] = []
+
+        for obj in objects:
+            if (
+                obj.object_type == "source_unit"
+                and obj.x is not None
+                and obj.y is not None
+            ):
+                fill_color, line_color, fill_alpha, line_alpha, line_width = (
+                    _source_visual_state(amount=obj.amount, color=obj.color)
+                )
+                food_rows.append(
+                    {
+                        "x": obj.x,
+                        "y": obj.y,
+                        "r": max(_safe_float(obj.radius, 0.003), 0.001),
+                        "fill_color": fill_color,
+                        "line_color": line_color,
+                        "id": obj.object_id,
+                        "fill_alpha": fill_alpha,
+                        "line_alpha": line_alpha,
+                        "line_width": line_width,
+                    }
+                )
+                odor_rows.extend(self._odor_rows_for(obj, obj.x, obj.y))
+                peak = self._odor_peak_for(obj, obj.x, obj.y)
+                if peak is not None:
+                    peak_rows.append(peak)
+            elif obj.object_type == "source_group":
+                self._append_group_footprint(
+                    obj, circle_rows, ellipse_rows, rect_rows, 0.08, 0.9
+                )
+                members = self._group_member_rows(obj)
+                member_rows.extend(members)
+                for member in members:
+                    x = member.get("x")
+                    y = member.get("y")
+                    odor_rows.extend(self._odor_rows_for(obj, x, y))
+                    peak = self._odor_peak_for(obj, x, y)
+                    if peak is not None:
+                        peak_rows.append(peak)
+            elif obj.object_type == "border_segment":
+                border_rows.append(
+                    {
+                        "x0": obj.x,
+                        "y0": obj.y,
+                        "x1": obj.x2,
+                        "y1": obj.y2,
+                        "w": max(1, int(_safe_float(obj.width, 0.001) * 1500)),
+                        "color": obj.color or LANE_MODELS_COLOR_DARK,
+                        "id": obj.object_id,
+                    }
+                )
+            elif obj.object_type == "larva_group":
+                self._append_group_footprint(
+                    obj,
+                    larva_circle_rows,
+                    larva_ellipse_rows,
+                    larva_rect_rows,
+                    0.06,
+                    0.72,
+                    default_color=DEFAULT_LARVA_COLOR,
+                )
+                larva_member_rows.extend(
+                    self._group_member_rows(obj, default_color=DEFAULT_LARVA_COLOR)
+                )
+
+        self.food_source.data = _rows_to_data(
+            food_rows,
+            [
+                "x",
+                "y",
+                "r",
+                "fill_color",
+                "line_color",
+                "id",
+                "fill_alpha",
+                "line_alpha",
+                "line_width",
+            ],
+        )
+        self.odor_layer_source.data = _rows_to_data(
+            odor_rows, ["x", "y", "r", "color", "fill_alpha", "id"]
+        )
+        self.odor_peak_source.data = _rows_to_data(
+            peak_rows, ["x", "y", "r", "color", "fill_alpha", "id"]
+        )
+        self.source_group_circle_source.data = _rows_to_data(
+            circle_rows, ["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.source_group_ellipse_source.data = _rows_to_data(
+            ellipse_rows,
+            ["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"],
+        )
+        self.source_group_rect_source.data = _rows_to_data(
+            rect_rows, ["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"]
+        )
+        self.source_group_member_source.data = _rows_to_data(
+            member_rows,
+            [
+                "x",
+                "y",
+                "r",
+                "fill_color",
+                "line_color",
+                "fill_alpha",
+                "line_alpha",
+                "line_width",
+                "parent_id",
+            ],
+        )
+        self.border_source.data = _rows_to_data(
+            border_rows, ["x0", "y0", "x1", "y1", "w", "color", "id"]
+        )
+        self.larva_group_circle_source.data = _rows_to_data(
+            larva_circle_rows,
+            ["x", "y", "r", "color", "fill_alpha", "line_alpha", "id"],
+        )
+        self.larva_group_ellipse_source.data = _rows_to_data(
+            larva_ellipse_rows,
+            ["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"],
+        )
+        self.larva_group_rect_source.data = _rows_to_data(
+            larva_rect_rows,
+            ["x", "y", "w", "h", "color", "fill_alpha", "line_alpha", "id"],
+        )
+        self.larva_group_member_source.data = _rows_to_data(
+            larva_member_rows,
+            [
+                "x",
+                "y",
+                "r",
+                "fill_color",
+                "line_color",
+                "fill_alpha",
+                "line_alpha",
+                "line_width",
+                "parent_id",
+            ],
+        )
+
+    def _odor_rows_for(
+        self, obj: CanvasObject, x: Any, y: Any
+    ) -> list[dict[str, object]]:
+        return _build_odor_layers(
+            x=None if x is None else _safe_float(x),
+            y=None if y is None else _safe_float(y),
+            source_radius=obj.radius,
+            odor_id=obj.odor_id,
+            odor_intensity=obj.odor_intensity,
+            odor_spread=obj.odor_spread,
+            color=obj.color,
+            source_id=obj.object_id,
+        )
+
+    def _odor_peak_for(
+        self, obj: CanvasObject, x: Any, y: Any
+    ) -> dict[str, object] | None:
+        return _build_odor_peak(
+            x=None if x is None else _safe_float(x),
+            y=None if y is None else _safe_float(y),
+            source_radius=obj.radius,
+            odor_id=obj.odor_id,
+            odor_intensity=obj.odor_intensity,
+            odor_spread=obj.odor_spread,
+            color=obj.color,
+            source_id=obj.object_id,
+        )
+
+    def _append_group_footprint(
+        self,
+        obj: CanvasObject,
+        circle_rows: list[dict[str, Any]],
+        ellipse_rows: list[dict[str, Any]],
+        rect_rows: list[dict[str, Any]],
+        fill_alpha: float,
+        line_alpha: float,
+        *,
+        default_color: str = DEFAULT_SOURCE_COLOR,
+    ) -> None:
+        if obj.x is None or obj.y is None:
+            return
+        if obj.distribution_show_shape is False:
+            return
+        width = max(_safe_float(obj.distribution_scale_x, 0.012) * 2.0, 0.002)
+        height = max(_safe_float(obj.distribution_scale_y, 0.012) * 2.0, 0.002)
+        color = str(obj.color or default_color)
+        row = {
+            "x": float(obj.x),
+            "y": float(obj.y),
+            "color": color,
+            "fill_alpha": fill_alpha,
+            "line_alpha": line_alpha,
+            "id": obj.object_id,
+        }
+        shape = _normalize_group_shape(obj.distribution_shape)
+        if shape == "circle" and math.isclose(
+            width, height, rel_tol=1e-6, abs_tol=1e-9
+        ):
+            circle_rows.append({**row, "r": max(width, height) / 2.0})
+        elif shape in {"circle", "oval"}:
+            ellipse_rows.append({**row, "w": width, "h": height})
+        else:
+            rect_rows.append({**row, "w": width, "h": height})
+
+    def _set_group_highlight(
+        self,
+        obj: CanvasObject,
+        circle_source: ColumnDataSource,
+        ellipse_source: ColumnDataSource,
+        rect_source: ColumnDataSource,
+    ) -> None:
+        if obj.x is None or obj.y is None:
+            return
+        width = max(_safe_float(obj.distribution_scale_x, 0.012) * 2.0, 0.002)
+        height = max(_safe_float(obj.distribution_scale_y, 0.012) * 2.0, 0.002)
+        shape = _normalize_group_shape(obj.distribution_shape)
+        if shape == "circle" and math.isclose(
+            width, height, rel_tol=1e-6, abs_tol=1e-9
+        ):
+            circle_source.data = {
+                "x": [obj.x],
+                "y": [obj.y],
+                "r": [max(width, height) / 2.0],
+                "color": [HIGHLIGHT_COLOR],
+            }
+        elif shape in {"circle", "oval"}:
+            ellipse_source.data = {
+                "x": [obj.x],
+                "y": [obj.y],
+                "w": [width],
+                "h": [height],
+                "color": [HIGHLIGHT_COLOR],
+            }
+        else:
+            rect_source.data = {
+                "x": [obj.x],
+                "y": [obj.y],
+                "w": [width],
+                "h": [height],
+                "color": [HIGHLIGHT_COLOR],
+            }
+
+    def _group_member_positions(self, obj: CanvasObject) -> list[tuple[float, float]]:
+        if (
+            obj.object_type not in {"source_group", "larva_group"}
+            or obj.x is None
+            or obj.y is None
+        ):
+            return []
+        count = _safe_int(obj.distribution_n, 0)
+        if count <= 0:
+            return []
+        distribution = Spatial_Distro(
+            N=count,
+            shape=_normalize_group_shape(obj.distribution_shape),
+            mode=str(obj.distribution_mode or "uniform"),
+            loc=(float(obj.x), float(obj.y)),
+            scale=(
+                float(obj.distribution_scale_x or 0.012),
+                float(obj.distribution_scale_y or 0.012),
+            ),
+        )
+        state = np.random.get_state()
+        seed = _stable_preview_seed(
+            obj.object_id,
+            obj.distribution_mode,
+            obj.distribution_shape,
+            obj.distribution_n,
+            obj.x,
+            obj.y,
+            obj.distribution_scale_x,
+            obj.distribution_scale_y,
+        )
+        try:
+            np.random.seed(seed)
+            return [
+                (float(member_x), float(member_y))
+                for member_x, member_y in distribution()
+            ]
+        except Exception:
+            return []
+        finally:
+            np.random.set_state(state)
+
+    def _group_member_rows(
+        self, obj: CanvasObject, *, default_color: str = DEFAULT_SOURCE_COLOR
+    ) -> list[dict[str, Any]]:
+        positions = self._group_member_positions(obj)
+        if not positions:
+            return []
+        base_color = str(obj.color or default_color)
+        fill_color = _mix_hex_colors(base_color, "#ffffff", 0.18)
+        line_color = _mix_hex_colors(base_color, "#111111", 0.04)
+        radius = max(_safe_float(obj.radius, 0.0018), 0.0012)
+        return [
+            {
+                "x": member_x,
+                "y": member_y,
+                "r": radius,
+                "fill_color": fill_color,
+                "line_color": line_color,
+                "fill_alpha": 0.78,
+                "line_alpha": 0.92,
+                "line_width": 1.4,
+                "parent_id": obj.object_id,
+            }
+            for member_x, member_y in positions
+        ]

--- a/src/larvaworld/portal/canvas_widgets/environment_canvas.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_canvas.py
@@ -561,7 +561,7 @@ class EnvironmentCanvas:
             fill_color="color",
             fill_alpha="fill_alpha",
         )
-        self._source_group_circle_renderer = self.fig.circle(
+        self._food_highlight_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -570,7 +570,7 @@ class EnvironmentCanvas:
             fill_color=None,
             line_width=4,
         )
-        self.fig.circle(
+        self._source_group_circle_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",

--- a/src/larvaworld/portal/canvas_widgets/environment_canvas.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_canvas.py
@@ -11,7 +11,12 @@ from bokeh.plotting import figure
 
 from larvaworld.lib.param.xy_distro import Spatial_Distro
 
-from .environment_models import CanvasArena, CanvasObject, EnvironmentCanvasState
+from .environment_models import (
+    CanvasArena,
+    CanvasObject,
+    EnvironmentCanvasState,
+    LarvaPreviewFrame,
+)
 
 
 LANE_MODELS_COLOR_DARK = "#5a4760"
@@ -56,6 +61,28 @@ def _safe_int(value: Any, default: int = 0) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _valid_xy(value: Any) -> tuple[float, float] | None:
+    if not isinstance(value, (list, tuple)) or len(value) < 2:
+        return None
+    try:
+        x = float(value[0])
+        y = float(value[1])
+    except (TypeError, ValueError):
+        return None
+    if not (math.isfinite(x) and math.isfinite(y)):
+        return None
+    return (x, y)
+
+
+def _valid_path(value: Any) -> tuple[tuple[float, float], ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    points = tuple(
+        xy for xy in (_valid_xy(candidate) for candidate in value) if xy is not None
+    )
+    return points if len(points) >= 2 else ()
 
 
 def _optional_float(value: Any, default: float) -> float:
@@ -396,6 +423,16 @@ class EnvironmentCanvas:
         self.larva_group_rect_highlight_source = ColumnDataSource(
             {"x": [], "y": [], "w": [], "h": [], "color": []}
         )
+        self.sim_larva_centroid_source = ColumnDataSource(
+            _empty(["x", "y", "color", "id"])
+        )
+        self.sim_larva_head_source = ColumnDataSource(_empty(["x", "y", "color", "id"]))
+        self.sim_larva_midline_source = ColumnDataSource(
+            _empty(["xs", "ys", "color", "id"])
+        )
+        self.sim_larva_trail_source = ColumnDataSource(
+            _empty(["xs", "ys", "color", "id"])
+        )
 
         self.fig = figure(
             title="Environment canvas",
@@ -561,15 +598,6 @@ class EnvironmentCanvas:
             fill_color="color",
             fill_alpha="fill_alpha",
         )
-        self._food_highlight_renderer = self.fig.circle(
-            x="x",
-            y="y",
-            radius="r",
-            source=self.food_highlight_source,
-            line_color=HIGHLIGHT_COLOR,
-            fill_color=None,
-            line_width=4,
-        )
         self._source_group_circle_renderer = self.fig.circle(
             x="x",
             y="y",
@@ -617,35 +645,6 @@ class EnvironmentCanvas:
             line_alpha="line_alpha",
             line_width="line_width",
         )
-        self.fig.circle(
-            x="x",
-            y="y",
-            radius="r",
-            source=self.source_group_circle_highlight_source,
-            line_color=HIGHLIGHT_COLOR,
-            fill_color=None,
-            line_width=4,
-        )
-        self.fig.ellipse(
-            x="x",
-            y="y",
-            width="w",
-            height="h",
-            source=self.source_group_ellipse_highlight_source,
-            line_color=HIGHLIGHT_COLOR,
-            fill_color=None,
-            line_width=4,
-        )
-        self.fig.rect(
-            x="x",
-            y="y",
-            width="w",
-            height="h",
-            source=self.source_group_rect_highlight_source,
-            line_color=HIGHLIGHT_COLOR,
-            fill_color=None,
-            line_width=4,
-        )
         self._border_renderer = self.fig.segment(
             x0="x0",
             y0="y0",
@@ -655,15 +654,6 @@ class EnvironmentCanvas:
             line_color="color",
             line_width="w",
             legend_label="Borders",
-        )
-        self.fig.segment(
-            x0="x0",
-            y0="y0",
-            x1="x1",
-            y1="y1",
-            source=self.border_highlight_source,
-            line_color=HIGHLIGHT_COLOR,
-            line_width="w",
         )
         self._larva_group_circle_renderer = self.fig.circle(
             x="x",
@@ -713,6 +703,89 @@ class EnvironmentCanvas:
             line_color="line_color",
             line_alpha="line_alpha",
             line_width="line_width",
+        )
+        self._sim_larva_trail_renderer = self.fig.multi_line(
+            xs="xs",
+            ys="ys",
+            source=self.sim_larva_trail_source,
+            line_color="color",
+            line_alpha=0.32,
+            line_width=1.5,
+        )
+        self._sim_larva_midline_renderer = self.fig.multi_line(
+            xs="xs",
+            ys="ys",
+            source=self.sim_larva_midline_source,
+            line_color="color",
+            line_alpha=0.85,
+            line_width=2.0,
+        )
+        self._sim_larva_centroid_renderer = self.fig.circle(
+            x="x",
+            y="y",
+            source=self.sim_larva_centroid_source,
+            size=6,
+            fill_color="color",
+            line_color="#111111",
+            fill_alpha=0.90,
+            line_alpha=0.75,
+        )
+        self._sim_larva_head_renderer = self.fig.circle(
+            x="x",
+            y="y",
+            source=self.sim_larva_head_source,
+            size=4,
+            fill_color="color",
+            line_color="#111111",
+            fill_alpha=1.0,
+            line_alpha=0.80,
+        )
+        self._food_highlight_renderer = self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.food_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.circle(
+            x="x",
+            y="y",
+            radius="r",
+            source=self.source_group_circle_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.ellipse(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.source_group_ellipse_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.rect(
+            x="x",
+            y="y",
+            width="w",
+            height="h",
+            source=self.source_group_rect_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            fill_color=None,
+            line_width=4,
+        )
+        self.fig.segment(
+            x0="x0",
+            y0="y0",
+            x1="x1",
+            y1="y1",
+            source=self.border_highlight_source,
+            line_color=HIGHLIGHT_COLOR,
+            line_width="w",
         )
         self.fig.circle(
             x="x",
@@ -782,6 +855,18 @@ class EnvironmentCanvas:
                 ],
             ),
             LegendItem(
+                label="Simulated larvae",
+                renderers=[
+                    self._sim_larva_centroid_renderer,
+                    self._sim_larva_head_renderer,
+                    self._sim_larva_midline_renderer,
+                ],
+            ),
+            LegendItem(
+                label="Larva trails",
+                renderers=[self._sim_larva_trail_renderer],
+            ),
+            LegendItem(
                 label="Odor aura",
                 renderers=[self._odor_aura_renderer, self._odor_peak_renderer],
             ),
@@ -807,6 +892,80 @@ class EnvironmentCanvas:
 
     def view(self) -> pn.viewable.Viewable:
         return self._pane
+
+    def set_larva_frame(self, frame: LarvaPreviewFrame) -> None:
+        centroid_rows: list[dict[str, Any]] = []
+        head_rows: list[dict[str, Any]] = []
+        midline_rows: list[dict[str, Any]] = []
+        trail_rows: list[dict[str, Any]] = []
+
+        for index, centroid in enumerate(frame.centroids):
+            centroid_xy = _valid_xy(centroid)
+            if centroid_xy is None:
+                continue
+            raw_color = frame.colors[index] if index < len(frame.colors) else None
+            color = str(raw_color) if raw_color else DEFAULT_LARVA_COLOR
+            larva_id = f"larva_{index}"
+            centroid_rows.append(
+                {
+                    "x": centroid_xy[0],
+                    "y": centroid_xy[1],
+                    "color": color,
+                    "id": larva_id,
+                }
+            )
+            if index < len(frame.heads):
+                head_xy = _valid_xy(frame.heads[index])
+                if head_xy is not None:
+                    head_rows.append(
+                        {
+                            "x": head_xy[0],
+                            "y": head_xy[1],
+                            "color": color,
+                            "id": larva_id,
+                        }
+                    )
+            if index < len(frame.midlines):
+                midline_points = _valid_path(frame.midlines[index])
+                if midline_points:
+                    midline_rows.append(
+                        {
+                            "xs": [point[0] for point in midline_points],
+                            "ys": [point[1] for point in midline_points],
+                            "color": color,
+                            "id": larva_id,
+                        }
+                    )
+            if index < len(frame.trails):
+                trail_points = _valid_path(frame.trails[index])
+                if trail_points:
+                    trail_rows.append(
+                        {
+                            "xs": [point[0] for point in trail_points],
+                            "ys": [point[1] for point in trail_points],
+                            "color": color,
+                            "id": larva_id,
+                        }
+                    )
+
+        self.sim_larva_centroid_source.data = _rows_to_data(
+            centroid_rows, ["x", "y", "color", "id"]
+        )
+        self.sim_larva_head_source.data = _rows_to_data(
+            head_rows, ["x", "y", "color", "id"]
+        )
+        self.sim_larva_midline_source.data = _rows_to_data(
+            midline_rows, ["xs", "ys", "color", "id"]
+        )
+        self.sim_larva_trail_source.data = _rows_to_data(
+            trail_rows, ["xs", "ys", "color", "id"]
+        )
+
+    def clear_larva_frame(self) -> None:
+        self.sim_larva_centroid_source.data = _empty(["x", "y", "color", "id"])
+        self.sim_larva_head_source.data = _empty(["x", "y", "color", "id"])
+        self.sim_larva_midline_source.data = _empty(["xs", "ys", "color", "id"])
+        self.sim_larva_trail_source.data = _empty(["xs", "ys", "color", "id"])
 
     def clear(self) -> None:
         self.arena_source.data = {"x": [], "y": [], "w": [], "h": []}
@@ -907,6 +1066,7 @@ class EnvironmentCanvas:
                 "parent_id",
             ]
         )
+        self.clear_larva_frame()
         self.set_selected_object(None)
         self._state = None
 

--- a/src/larvaworld/portal/canvas_widgets/environment_canvas.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_canvas.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable
 import numpy as np
 import panel as pn
 from bokeh.colors import named as named_colors
-from bokeh.models import ColumnDataSource, WheelZoomTool
+from bokeh.models import ColumnDataSource, LegendItem, WheelZoomTool
 from bokeh.plotting import figure
 
 from larvaworld.lib.param.xy_distro import Spatial_Distro
@@ -56,6 +56,24 @@ def _safe_int(value: Any, default: int = 0) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _optional_float(value: Any, default: float) -> float:
+    if value is None:
+        return default
+    return _safe_float(value, default)
+
+
+def _distribution_scale_pair(obj: CanvasObject) -> tuple[float, float]:
+    if obj.object_type == "source_group":
+        return (
+            _safe_float(obj.distribution_scale_x or 0.012, 0.012),
+            _safe_float(obj.distribution_scale_y or 0.012, 0.012),
+        )
+    return (
+        _optional_float(obj.distribution_scale_x, 0.012),
+        _optional_float(obj.distribution_scale_y, 0.012),
+    )
 
 
 def _mix_hex_colors(color_a: Any, color_b: Any, ratio: float) -> str:
@@ -124,6 +142,23 @@ def _stable_preview_seed(*parts: object) -> int:
             seed ^= ord(char)
             seed = (seed * 16777619) & 0xFFFFFFFF
     return seed
+
+
+def _stable_member_angle(obj: CanvasObject, member_index: int) -> float:
+    seed = _stable_preview_seed(
+        "larva_member_angle",
+        obj.object_id,
+        member_index,
+        obj.distribution_mode,
+        obj.distribution_shape,
+        obj.distribution_n,
+        obj.x,
+        obj.y,
+        obj.distribution_scale_x,
+        obj.distribution_scale_y,
+    )
+    rng = np.random.default_rng(seed)
+    return float(rng.uniform(0.0, 2.0 * math.pi))
 
 
 def _normalize_group_shape(value: str | None) -> str:
@@ -339,9 +374,10 @@ class EnvironmentCanvas:
         self.larva_group_member_source = ColumnDataSource(
             _empty(
                 [
-                    "x",
-                    "y",
-                    "r",
+                    "x0",
+                    "y0",
+                    "x1",
+                    "y1",
                     "fill_color",
                     "line_color",
                     "fill_alpha",
@@ -437,7 +473,7 @@ class EnvironmentCanvas:
             fill_color="fill_color",
             fill_alpha="fill_alpha",
         )
-        self.fig.circle(
+        self._thermoscape_aura_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -449,7 +485,7 @@ class EnvironmentCanvas:
             line_width=1,
             legend_label="Thermoscape",
         )
-        self.fig.segment(
+        self._windscape_segment_renderer = self.fig.segment(
             x0="x0",
             y0="y0",
             x1="x1",
@@ -460,7 +496,7 @@ class EnvironmentCanvas:
             line_width=2,
             legend_label="Windscape",
         )
-        self.fig.scatter(
+        self._windscape_head_renderer = self.fig.scatter(
             x="x",
             y="y",
             source=self.windscape_head_source,
@@ -472,7 +508,7 @@ class EnvironmentCanvas:
             fill_alpha=0.75,
             line_alpha=0.85,
         )
-        self.fig.circle(
+        self._odorscape_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -483,7 +519,7 @@ class EnvironmentCanvas:
             fill_alpha=0.0,
             legend_label="Odorscape",
         )
-        self.fig.scatter(
+        self._thermoscape_marker_renderer = self.fig.scatter(
             x="x",
             y="y",
             source=self.thermoscape_marker_source,
@@ -494,7 +530,7 @@ class EnvironmentCanvas:
             fill_alpha=0.9,
             line_alpha=0.95,
         )
-        self.fig.circle(
+        self._odor_aura_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -504,7 +540,7 @@ class EnvironmentCanvas:
             fill_alpha="fill_alpha",
             legend_label="Odor aura",
         )
-        self.fig.circle(
+        self._source_units_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -516,7 +552,7 @@ class EnvironmentCanvas:
             line_width="line_width",
             legend_label="Source units",
         )
-        self.fig.circle(
+        self._odor_peak_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -525,7 +561,7 @@ class EnvironmentCanvas:
             fill_color="color",
             fill_alpha="fill_alpha",
         )
-        self.fig.circle(
+        self._source_group_circle_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -546,7 +582,7 @@ class EnvironmentCanvas:
             line_width=2,
             legend_label="Source groups",
         )
-        self.fig.ellipse(
+        self._source_group_ellipse_renderer = self.fig.ellipse(
             x="x",
             y="y",
             width="w",
@@ -558,7 +594,7 @@ class EnvironmentCanvas:
             line_alpha="line_alpha",
             line_width=2,
         )
-        self.fig.rect(
+        self._source_group_rect_renderer = self.fig.rect(
             x="x",
             y="y",
             width="w",
@@ -570,7 +606,7 @@ class EnvironmentCanvas:
             line_alpha="line_alpha",
             line_width=2,
         )
-        self.fig.circle(
+        self._source_group_member_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -610,7 +646,7 @@ class EnvironmentCanvas:
             fill_color=None,
             line_width=4,
         )
-        self.fig.segment(
+        self._border_renderer = self.fig.segment(
             x0="x0",
             y0="y0",
             x1="x1",
@@ -629,7 +665,7 @@ class EnvironmentCanvas:
             line_color=HIGHLIGHT_COLOR,
             line_width="w",
         )
-        self.fig.circle(
+        self._larva_group_circle_renderer = self.fig.circle(
             x="x",
             y="y",
             radius="r",
@@ -642,7 +678,7 @@ class EnvironmentCanvas:
             line_width=2,
             legend_label="Larva groups",
         )
-        self.fig.ellipse(
+        self._larva_group_ellipse_renderer = self.fig.ellipse(
             x="x",
             y="y",
             width="w",
@@ -655,7 +691,7 @@ class EnvironmentCanvas:
             line_dash="dashed",
             line_width=2,
         )
-        self.fig.rect(
+        self._larva_group_rect_renderer = self.fig.rect(
             x="x",
             y="y",
             width="w",
@@ -668,14 +704,13 @@ class EnvironmentCanvas:
             line_dash="dashed",
             line_width=2,
         )
-        self.fig.circle(
-            x="x",
-            y="y",
-            radius="r",
+        self._larva_group_member_renderer = self.fig.segment(
+            x0="x0",
+            y0="y0",
+            x1="x1",
+            y1="y1",
             source=self.larva_group_member_source,
             line_color="line_color",
-            fill_color="fill_color",
-            fill_alpha="fill_alpha",
             line_alpha="line_alpha",
             line_width="line_width",
         )
@@ -708,10 +743,67 @@ class EnvironmentCanvas:
             fill_color=None,
             line_width=4,
         )
+        self._order_legend()
+
         self.fig.legend.click_policy = "hide"
         self.fig.legend.location = "top_left"
+        self.fig.legend.background_fill_alpha = 0.85
 
         self._pane = pn.pane.Bokeh(self.fig, sizing_mode="stretch_width")
+
+    def _order_legend(self) -> None:
+        if not self.fig.legend:
+            return
+        self.fig.legend[0].items = [
+            LegendItem(
+                label="Source units",
+                renderers=[self._source_units_renderer],
+            ),
+            LegendItem(
+                label="Source groups",
+                renderers=[
+                    self._source_group_circle_renderer,
+                    self._source_group_ellipse_renderer,
+                    self._source_group_rect_renderer,
+                    self._source_group_member_renderer,
+                ],
+            ),
+            LegendItem(
+                label="Borders",
+                renderers=[self._border_renderer],
+            ),
+            LegendItem(
+                label="Larva groups",
+                renderers=[
+                    self._larva_group_circle_renderer,
+                    self._larva_group_ellipse_renderer,
+                    self._larva_group_rect_renderer,
+                    self._larva_group_member_renderer,
+                ],
+            ),
+            LegendItem(
+                label="Odor aura",
+                renderers=[self._odor_aura_renderer, self._odor_peak_renderer],
+            ),
+            LegendItem(
+                label="Odorscape",
+                renderers=[self._odorscape_renderer],
+            ),
+            LegendItem(
+                label="Windscape",
+                renderers=[
+                    self._windscape_segment_renderer,
+                    self._windscape_head_renderer,
+                ],
+            ),
+            LegendItem(
+                label="Thermoscape",
+                renderers=[
+                    self._thermoscape_aura_renderer,
+                    self._thermoscape_marker_renderer,
+                ],
+            ),
+        ]
 
     def view(self) -> pn.viewable.Viewable:
         return self._pane
@@ -803,9 +895,10 @@ class EnvironmentCanvas:
         )
         self.larva_group_member_source.data = _empty(
             [
-                "x",
-                "y",
-                "r",
+                "x0",
+                "y0",
+                "x1",
+                "y1",
                 "fill_color",
                 "line_color",
                 "fill_alpha",
@@ -1336,9 +1429,10 @@ class EnvironmentCanvas:
         self.larva_group_member_source.data = _rows_to_data(
             larva_member_rows,
             [
-                "x",
-                "y",
-                "r",
+                "x0",
+                "y0",
+                "x1",
+                "y1",
                 "fill_color",
                 "line_color",
                 "fill_alpha",
@@ -1391,8 +1485,9 @@ class EnvironmentCanvas:
             return
         if obj.distribution_show_shape is False:
             return
-        width = max(_safe_float(obj.distribution_scale_x, 0.012) * 2.0, 0.002)
-        height = max(_safe_float(obj.distribution_scale_y, 0.012) * 2.0, 0.002)
+        scale_x, scale_y = _distribution_scale_pair(obj)
+        width = max(scale_x * 2.0, 0.002)
+        height = max(scale_y * 2.0, 0.002)
         color = str(obj.color or default_color)
         row = {
             "x": float(obj.x),
@@ -1403,8 +1498,9 @@ class EnvironmentCanvas:
             "id": obj.object_id,
         }
         shape = _normalize_group_shape(obj.distribution_shape)
-        if shape == "circle" and math.isclose(
-            width, height, rel_tol=1e-6, abs_tol=1e-9
+        if shape == "circle" and (
+            obj.object_type == "source_group"
+            or math.isclose(width, height, rel_tol=1e-6, abs_tol=1e-9)
         ):
             circle_rows.append({**row, "r": max(width, height) / 2.0})
         elif shape in {"circle", "oval"}:
@@ -1421,11 +1517,13 @@ class EnvironmentCanvas:
     ) -> None:
         if obj.x is None or obj.y is None:
             return
-        width = max(_safe_float(obj.distribution_scale_x, 0.012) * 2.0, 0.002)
-        height = max(_safe_float(obj.distribution_scale_y, 0.012) * 2.0, 0.002)
+        scale_x, scale_y = _distribution_scale_pair(obj)
+        width = max(scale_x * 2.0, 0.002)
+        height = max(scale_y * 2.0, 0.002)
         shape = _normalize_group_shape(obj.distribution_shape)
-        if shape == "circle" and math.isclose(
-            width, height, rel_tol=1e-6, abs_tol=1e-9
+        if shape == "circle" and (
+            obj.object_type == "source_group"
+            or math.isclose(width, height, rel_tol=1e-6, abs_tol=1e-9)
         ):
             circle_source.data = {
                 "x": [obj.x],
@@ -1465,10 +1563,7 @@ class EnvironmentCanvas:
             shape=_normalize_group_shape(obj.distribution_shape),
             mode=str(obj.distribution_mode or "uniform"),
             loc=(float(obj.x), float(obj.y)),
-            scale=(
-                float(obj.distribution_scale_x or 0.012),
-                float(obj.distribution_scale_y or 0.012),
-            ),
+            scale=_distribution_scale_pair(obj),
         )
         state = np.random.get_state()
         seed = _stable_preview_seed(
@@ -1501,6 +1596,28 @@ class EnvironmentCanvas:
         base_color = str(obj.color or default_color)
         fill_color = _mix_hex_colors(base_color, "#ffffff", 0.18)
         line_color = _mix_hex_colors(base_color, "#111111", 0.04)
+        if obj.object_type == "larva_group":
+            half_len = 0.00045
+            rows: list[dict[str, Any]] = []
+            for idx, (member_x, member_y) in enumerate(positions):
+                angle = _stable_member_angle(obj, idx)
+                dx = half_len * math.cos(angle)
+                dy = half_len * math.sin(angle)
+                rows.append(
+                    {
+                        "x0": member_x - dx,
+                        "y0": member_y - dy,
+                        "x1": member_x + dx,
+                        "y1": member_y + dy,
+                        "fill_color": fill_color,
+                        "line_color": line_color,
+                        "fill_alpha": 0.0,
+                        "line_alpha": 0.95,
+                        "line_width": 1.4,
+                        "parent_id": obj.object_id,
+                    }
+                )
+            return rows
         radius = max(_safe_float(obj.radius, 0.0018), 0.0012)
         return [
             {

--- a/src/larvaworld/portal/canvas_widgets/environment_canvas.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_canvas.py
@@ -23,6 +23,7 @@ LANE_MODELS_COLOR_DARK = "#5a4760"
 DEFAULT_SOURCE_COLOR = "#4caf50"
 DEFAULT_LARVA_COLOR = "#2f4858"
 HIGHLIGHT_COLOR = "#f97316"
+STATIC_LARVA_GROUP_MEMBER_HALF_LENGTH = 0.0015
 ENV_CANVAS_WIDTH = 760
 ENV_CANVAS_HEIGHT = 620
 ENV_CANVAS_Y_HALF_RANGE = 0.30
@@ -1757,12 +1758,11 @@ class EnvironmentCanvas:
         fill_color = _mix_hex_colors(base_color, "#ffffff", 0.18)
         line_color = _mix_hex_colors(base_color, "#111111", 0.04)
         if obj.object_type == "larva_group":
-            half_len = 0.00045
             rows: list[dict[str, Any]] = []
             for idx, (member_x, member_y) in enumerate(positions):
                 angle = _stable_member_angle(obj, idx)
-                dx = half_len * math.cos(angle)
-                dy = half_len * math.sin(angle)
+                dx = STATIC_LARVA_GROUP_MEMBER_HALF_LENGTH * math.cos(angle)
+                dy = STATIC_LARVA_GROUP_MEMBER_HALF_LENGTH * math.sin(angle)
                 rows.append(
                     {
                         "x0": member_x - dx,

--- a/src/larvaworld/portal/canvas_widgets/environment_mapping.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_mapping.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .environment_models import CanvasArena, CanvasObject, EnvironmentCanvasState
+
+
+def env_params_to_canvas_state(
+    env_params: Any,
+    *,
+    larva_groups: Mapping[str, Any] | None = None,
+) -> EnvironmentCanvasState:
+    """Map resolved environment parameters into normalized canvas state."""
+
+    arena_conf = _get(env_params, "arena", {})
+    arena = CanvasArena(
+        geometry=str(_get(arena_conf, "geometry", "rectangular") or "rectangular"),
+        dims=_pair(_get(arena_conf, "dims", (0.2, 0.2)), default=(0.2, 0.2)),
+        torus=bool(_get(arena_conf, "torus", False)),
+    )
+
+    objects: list[CanvasObject] = []
+    food_params = _get(env_params, "food_params", {})
+    source_units = _get(food_params, "source_units", {}) or {}
+    source_groups = _get(food_params, "source_groups", {}) or {}
+    border_list = _get(env_params, "border_list", {}) or {}
+
+    if _is_mapping(source_units):
+        for source_id, source in source_units.items():
+            obj = _source_unit_to_canvas_object(str(source_id), source)
+            if obj is not None:
+                objects.append(obj)
+
+    if _is_mapping(source_groups):
+        for group_id, group in source_groups.items():
+            obj = _source_group_to_canvas_object(str(group_id), group)
+            if obj is not None:
+                objects.append(obj)
+
+    if _is_mapping(border_list):
+        for border_id, border in border_list.items():
+            objects.extend(_border_to_canvas_objects(str(border_id), border))
+
+    if _is_mapping(larva_groups):
+        for group_id, group in larva_groups.items():
+            obj = _larva_group_to_canvas_object(str(group_id), group)
+            if obj is not None:
+                objects.append(obj)
+
+    return EnvironmentCanvasState(
+        arena=arena,
+        objects=tuple(objects),
+        food_grid=_optional_mapping(_get(food_params, "food_grid", None)),
+        odorscape=_optional_mapping(_get(env_params, "odorscape", None)),
+        windscape=_optional_mapping(_get(env_params, "windscape", None)),
+        thermoscape=_optional_mapping(_get(env_params, "thermoscape", None)),
+    )
+
+
+def _source_unit_to_canvas_object(object_id: str, source: Any) -> CanvasObject | None:
+    pos = _pair(_get(source, "pos", None), default=(None, None))
+    x, y = pos
+    if x is None or y is None:
+        return None
+    odor = _get(source, "odor", {}) or {}
+    return CanvasObject(
+        object_id=object_id,
+        object_type="source_unit",
+        x=x,
+        y=y,
+        radius=_float_or_none(_get(source, "radius", 0.003)),
+        color=_str_or_none(_get(source, "color", None)),
+        amount=_float_or_none(_get(source, "amount", None)),
+        odor_id=_str_or_none(_get(odor, "id", None)),
+        odor_intensity=_float_or_none(_get(odor, "intensity", None)),
+        odor_spread=_float_or_none(_get(odor, "spread", None)),
+    )
+
+
+def _source_group_to_canvas_object(object_id: str, group: Any) -> CanvasObject | None:
+    distribution = _get(group, "distribution", {}) or {}
+    pos = _pair(
+        _get(distribution, "loc", _get(group, "pos", None)), default=(None, None)
+    )
+    x, y = pos
+    if x is None or y is None:
+        return None
+    scale = _pair(_get(distribution, "scale", None), default=(0.012, 0.012))
+    odor = _get(group, "odor", {}) or {}
+    return CanvasObject(
+        object_id=object_id,
+        object_type="source_group",
+        x=x,
+        y=y,
+        radius=_float_or_none(_get(group, "radius", 0.003)),
+        color=_str_or_none(_get(group, "color", None)),
+        amount=_float_or_none(_get(group, "amount", None)),
+        odor_id=_str_or_none(_get(odor, "id", None)),
+        odor_intensity=_float_or_none(_get(odor, "intensity", None)),
+        odor_spread=_float_or_none(_get(odor, "spread", None)),
+        distribution_mode=_str_or_none(_get(distribution, "mode", "uniform")),
+        distribution_shape=_str_or_none(_get(distribution, "shape", "circle")),
+        distribution_n=_int_or_none(_get(distribution, "N", None)),
+        distribution_scale_x=scale[0],
+        distribution_scale_y=scale[1],
+        distribution_show_shape=bool(_get(group, "distribution_show_shape", True)),
+    )
+
+
+def _border_to_canvas_objects(object_id: str, border: Any) -> list[CanvasObject]:
+    vertices = _get(border, "vertices", None)
+    segments: list[tuple[tuple[float, float], tuple[float, float]]] = []
+    if vertices is not None:
+        segments.extend(_paired_segments(vertices))
+    if not segments:
+        border_xy = _get(border, "border_xy", None)
+        if isinstance(border_xy, (list, tuple)):
+            for path in border_xy:
+                segments.extend(_paired_segments(path))
+    width = _float_or_none(_get(border, "width", 0.001))
+    color = _str_or_none(_get(border, "color", "#333333"))
+    objects: list[CanvasObject] = []
+    for index, ((x0, y0), (x1, y1)) in enumerate(segments):
+        objects.append(
+            CanvasObject(
+                object_id=object_id if len(segments) == 1 else f"{object_id}:{index}",
+                object_type="border_segment",
+                x=x0,
+                y=y0,
+                x2=x1,
+                y2=y1,
+                width=width,
+                color=color,
+            )
+        )
+    return objects
+
+
+def _larva_group_to_canvas_object(object_id: str, group: Any) -> CanvasObject | None:
+    distribution = _get(group, "distribution", {}) or {}
+    pos = _pair(_get(distribution, "loc", None), default=(None, None))
+    x, y = pos
+    if x is None or y is None:
+        return None
+    scale = _pair(_get(distribution, "scale", None), default=(0.012, 0.012))
+    return CanvasObject(
+        object_id=object_id,
+        object_type="larva_group",
+        x=x,
+        y=y,
+        color=_str_or_none(_get(group, "color", None)),
+        distribution_mode=_str_or_none(_get(distribution, "mode", "uniform")),
+        distribution_shape=_str_or_none(_get(distribution, "shape", "circle")),
+        distribution_n=_int_or_none(_get(distribution, "N", None)),
+        distribution_scale_x=scale[0],
+        distribution_scale_y=scale[1],
+        distribution_show_shape=True,
+    )
+
+
+def _optional_mapping(value: Any) -> dict[str, Any] | None:
+    if value in (None, {}, "empty_dict"):
+        return None
+    if not _is_mapping(value):
+        return None
+    plain = _to_plain(value)
+    return plain if isinstance(plain, dict) and plain else None
+
+
+def _to_plain(value: Any) -> Any:
+    if _is_mapping(value):
+        return {str(key): _to_plain(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return tuple(_to_plain(item) for item in value)
+    if isinstance(value, list):
+        return [_to_plain(item) for item in value]
+    if hasattr(value, "__array__"):
+        try:
+            return [_to_plain(item) for item in list(value)]
+        except Exception:
+            return None
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return value
+
+
+def _is_mapping(value: Any) -> bool:
+    return isinstance(value, Mapping) or hasattr(value, "items")
+
+
+def _get(value: Any, key: str, default: Any = None) -> Any:
+    if value is None:
+        return default
+    if _is_mapping(value):
+        try:
+            return value.get(key, default)
+        except Exception:
+            pass
+    return getattr(value, key, default)
+
+
+def _pair(value: Any, *, default: tuple[Any, Any]) -> tuple[Any, Any]:
+    try:
+        if value is None:
+            return default
+        if isinstance(value, (list, tuple)) and len(value) >= 2:
+            return (_float_or_none(value[0]), _float_or_none(value[1]))
+        if hasattr(value, "__array__"):
+            items = list(value)
+            if len(items) >= 2:
+                return (_float_or_none(items[0]), _float_or_none(items[1]))
+    except Exception:
+        return default
+    return default
+
+
+def _paired_segments(
+    value: Any,
+) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+    try:
+        points = list(value)
+    except Exception:
+        return []
+    if len(points) < 2:
+        return []
+    segments: list[tuple[tuple[float, float], tuple[float, float]]] = []
+    for index in range(0, len(points) - 1, 2):
+        first = _pair(points[index], default=(None, None))
+        second = _pair(points[index + 1], default=(None, None))
+        if None in first or None in second:
+            continue
+        segments.append(((first[0], first[1]), (second[0], second[1])))
+    return segments
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None

--- a/src/larvaworld/portal/canvas_widgets/environment_mapping.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_mapping.py
@@ -10,6 +10,7 @@ def env_params_to_canvas_state(
     env_params: Any,
     *,
     larva_groups: Mapping[str, Any] | None = None,
+    show_group_shapes: bool = True,
 ) -> EnvironmentCanvasState:
     """Map resolved environment parameters into normalized canvas state."""
 
@@ -34,7 +35,9 @@ def env_params_to_canvas_state(
 
     if _is_mapping(source_groups):
         for group_id, group in source_groups.items():
-            obj = _source_group_to_canvas_object(str(group_id), group)
+            obj = _source_group_to_canvas_object(
+                str(group_id), group, show_shape=show_group_shapes
+            )
             if obj is not None:
                 objects.append(obj)
 
@@ -44,7 +47,9 @@ def env_params_to_canvas_state(
 
     if _is_mapping(larva_groups):
         for group_id, group in larva_groups.items():
-            obj = _larva_group_to_canvas_object(str(group_id), group)
+            obj = _larva_group_to_canvas_object(
+                str(group_id), group, show_shape=show_group_shapes
+            )
             if obj is not None:
                 objects.append(obj)
 
@@ -78,7 +83,9 @@ def _source_unit_to_canvas_object(object_id: str, source: Any) -> CanvasObject |
     )
 
 
-def _source_group_to_canvas_object(object_id: str, group: Any) -> CanvasObject | None:
+def _source_group_to_canvas_object(
+    object_id: str, group: Any, *, show_shape: bool
+) -> CanvasObject | None:
     distribution = _get(group, "distribution", {}) or {}
     pos = _pair(
         _get(distribution, "loc", _get(group, "pos", None)), default=(None, None)
@@ -104,7 +111,9 @@ def _source_group_to_canvas_object(object_id: str, group: Any) -> CanvasObject |
         distribution_n=_int_or_none(_get(distribution, "N", None)),
         distribution_scale_x=scale[0],
         distribution_scale_y=scale[1],
-        distribution_show_shape=bool(_get(group, "distribution_show_shape", True)),
+        distribution_show_shape=(
+            bool(_get(group, "distribution_show_shape", True)) if show_shape else False
+        ),
     )
 
 
@@ -137,7 +146,9 @@ def _border_to_canvas_objects(object_id: str, border: Any) -> list[CanvasObject]
     return objects
 
 
-def _larva_group_to_canvas_object(object_id: str, group: Any) -> CanvasObject | None:
+def _larva_group_to_canvas_object(
+    object_id: str, group: Any, *, show_shape: bool
+) -> CanvasObject | None:
     distribution = _get(group, "distribution", {}) or {}
     pos = _pair(_get(distribution, "loc", None), default=(None, None))
     x, y = pos
@@ -155,7 +166,7 @@ def _larva_group_to_canvas_object(object_id: str, group: Any) -> CanvasObject | 
         distribution_n=_int_or_none(_get(distribution, "N", None)),
         distribution_scale_x=scale[0],
         distribution_scale_y=scale[1],
-        distribution_show_shape=True,
+        distribution_show_shape=show_shape,
     )
 
 

--- a/src/larvaworld/portal/canvas_widgets/environment_models.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_models.py
@@ -49,3 +49,13 @@ class EnvironmentCanvasState:
     odorscape: dict[str, Any] | None = None
     windscape: dict[str, Any] | None = None
     thermoscape: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class LarvaPreviewFrame:
+    tick: int
+    centroids: tuple[tuple[float, float], ...] = ()
+    heads: tuple[tuple[float, float], ...] = ()
+    midlines: tuple[tuple[tuple[float, float], ...], ...] = ()
+    trails: tuple[tuple[tuple[float, float], ...], ...] = ()
+    colors: tuple[str, ...] = ()

--- a/src/larvaworld/portal/canvas_widgets/environment_models.py
+++ b/src/larvaworld/portal/canvas_widgets/environment_models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+CanvasObjectType = Literal[
+    "source_unit",
+    "source_group",
+    "border_segment",
+    "larva_group",
+]
+
+
+@dataclass(frozen=True)
+class CanvasArena:
+    geometry: str
+    dims: tuple[float, float]
+    torus: bool = False
+
+
+@dataclass(frozen=True)
+class CanvasObject:
+    object_id: str
+    object_type: CanvasObjectType
+    x: float | None = None
+    y: float | None = None
+    x2: float | None = None
+    y2: float | None = None
+    radius: float | None = None
+    width: float | None = None
+    color: str | None = None
+    amount: float | None = None
+    odor_id: str | None = None
+    odor_intensity: float | None = None
+    odor_spread: float | None = None
+    distribution_mode: str | None = None
+    distribution_shape: str | None = None
+    distribution_n: int | None = None
+    distribution_scale_x: float | None = None
+    distribution_scale_y: float | None = None
+    distribution_show_shape: bool | None = None
+
+
+@dataclass(frozen=True)
+class EnvironmentCanvasState:
+    arena: CanvasArena
+    objects: tuple[CanvasObject, ...] = ()
+    food_grid: dict[str, Any] | None = None
+    odorscape: dict[str, Any] | None = None
+    windscape: dict[str, Any] | None = None
+    thermoscape: dict[str, Any] | None = None

--- a/src/larvaworld/portal/config_widgets/__init__.py
+++ b/src/larvaworld/portal/config_widgets/__init__.py
@@ -1,5 +1,6 @@
 from .arena_widget import build_area_widget
 from .border_widget import build_border_widget
+from .conftype_actions import ConftypeActionsController, build_conftype_actions
 from .conftype_widget import (
     ConftypeWidgetController,
     build_conftype_widget,
@@ -8,6 +9,7 @@ from .conftype_widget import (
 from .conftypes_demo_app import conftypes_demo_app
 from .distribution_widget import build_distribution_widget
 from .env_widget import build_env_params_widget
+from .enrichment_widget import build_enrichment_widget, build_preprocess_conf_widget
 from .food_widget import build_food_conf_widget
 from .odorscape_widget import build_odorscape_widget
 from .thermoscape_widget import build_thermoscape_widget
@@ -17,11 +19,15 @@ from .windscape_widget import build_windscape_widget
 __all__ = [
     "build_area_widget",
     "build_border_widget",
+    "ConftypeActionsController",
     "ConftypeWidgetController",
+    "build_conftype_actions",
     "build_conftype_widget",
     "build_distribution_widget",
     "build_env_params_widget",
+    "build_enrichment_widget",
     "build_food_conf_widget",
+    "build_preprocess_conf_widget",
     "build_odorscape_widget",
     "collapsible_family_box",
     "resolve_conftype",

--- a/src/larvaworld/portal/config_widgets/conftype_actions.py
+++ b/src/larvaworld/portal/config_widgets/conftype_actions.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import panel as pn
+import param
+
+from larvaworld.lib import reg
+
+__all__ = ["ConftypeActionsController", "build_conftype_actions"]
+
+
+def _is_parameterized_class(config_cls: type[Any]) -> bool:
+    return isinstance(config_cls, type) and issubclass(config_cls, param.Parameterized)
+
+
+def _matches_registered_class(
+    config_cls: type[param.Parameterized], candidate_cls: type[Any]
+) -> bool:
+    if not _is_parameterized_class(candidate_cls):
+        return False
+    if candidate_cls is config_cls:
+        return True
+    try:
+        return issubclass(config_cls, candidate_cls) or issubclass(
+            candidate_cls, config_cls
+        )
+    except TypeError:
+        pass
+    agent_class = getattr(candidate_cls, "agent_class", None)
+    if callable(agent_class):
+        try:
+            return agent_class() == config_cls.__name__
+        except Exception:
+            return False
+    return False
+
+
+def _widget_size(
+    *,
+    width: int | None,
+    sizing_mode: str,
+) -> dict[str, Any]:
+    if width is not None:
+        return {"width": width}
+    return {"sizing_mode": sizing_mode}
+
+
+class ConftypeActionsController:
+    def __init__(
+        self,
+        config_cls: type[param.Parameterized],
+        *,
+        conftype: str,
+        build_save_payload: Callable[[str], Any],
+        get_selected_id: Callable[[], str | None],
+        get_save_id: Callable[[], str | None] | None = None,
+        on_load: Callable[[str, Any], None] | None = None,
+        on_save: Callable[[str, Any], None] | None = None,
+        on_delete: Callable[[str], None] | None = None,
+        on_reset: Callable[[str | None], None] | None = None,
+        on_status: Callable[..., None] | None = None,
+        allow_reset: bool = True,
+        confirm_reset: bool = True,
+        load_button_name: str = "Load",
+        save_button_name: str = "Save",
+        delete_button_name: str = "Delete",
+        reset_button_name: str = "Reset configurations",
+        load_button_type: str = "primary",
+        save_button_type: str = "primary",
+        delete_button_type: str = "warning",
+        reset_button_type: str = "danger",
+        button_width: int | None = None,
+        sizing_mode: str = "stretch_width",
+    ) -> None:
+        if not _is_parameterized_class(config_cls):
+            raise TypeError("config_cls must be a param.Parameterized subclass.")
+        if conftype not in reg.conf:
+            raise ValueError(f'Unknown conftype "{conftype}".')
+
+        self.config_cls = config_cls
+        self.conf_type = reg.conf[conftype]
+        if not _matches_registered_class(config_cls, self.conf_type.conf_class):
+            raise ValueError(
+                f"{config_cls.__name__} does not match conftype "
+                f'"{self.conf_type.conftype}".'
+            )
+
+        self.build_save_payload = build_save_payload
+        self.get_selected_id = get_selected_id
+        self.get_save_id = get_save_id or get_selected_id
+        self.on_load = on_load
+        self.on_save = on_save
+        self.on_delete = on_delete
+        self.on_reset = on_reset
+        self.on_status = on_status
+        self.confirm_reset = confirm_reset
+
+        self.load_button = pn.widgets.Button(
+            name=load_button_name,
+            button_type=load_button_type,
+            **_widget_size(width=button_width, sizing_mode=sizing_mode),
+        )
+        self.save_button = pn.widgets.Button(
+            name=save_button_name,
+            button_type=save_button_type,
+            **_widget_size(width=button_width, sizing_mode=sizing_mode),
+        )
+        self.delete_button = pn.widgets.Button(
+            name=delete_button_name,
+            button_type=delete_button_type,
+            **_widget_size(width=button_width, sizing_mode=sizing_mode),
+        )
+        self.reset_button = pn.widgets.Button(
+            name=reset_button_name,
+            button_type=reset_button_type,
+            visible=allow_reset,
+            **_widget_size(width=button_width, sizing_mode=sizing_mode),
+        )
+        self.reset_confirm_host = pn.Column(sizing_mode="stretch_width")
+
+        self.load_button.on_click(lambda _event: self.load_selected())
+        self.save_button.on_click(lambda _event: self.save_current())
+        self.delete_button.on_click(lambda _event: self.delete_selected())
+        self.reset_button.on_click(lambda _event: self.request_reset())
+
+        self.view = pn.Column(
+            pn.Row(
+                self.load_button,
+                self.save_button,
+                self.delete_button,
+                sizing_mode="stretch_width",
+            ),
+            pn.Row(
+                self.reset_button,
+                sizing_mode="stretch_width",
+                visible=allow_reset,
+            ),
+            self.reset_confirm_host,
+            sizing_mode="stretch_width",
+        )
+
+    def _selected_id(self) -> str | None:
+        value = self.get_selected_id()
+        return str(value) if value else None
+
+    def _save_id(self) -> str | None:
+        value = self.get_save_id()
+        return str(value) if value else None
+
+    def _set_status(self, message: str, *, tone: str = "neutral") -> None:
+        if self.on_status is not None:
+            self.on_status(message, tone=tone)
+
+    def refresh_registry(self) -> None:
+        self.conf_type.load()
+
+    def load_selected(self) -> bool:
+        config_id = self._selected_id()
+        if not config_id:
+            self._set_status("Select a stored configuration to load.", tone="warning")
+            return False
+        try:
+            self.conf_type.load()
+            config = self.conf_type.get(config_id)
+        except Exception as exc:
+            self._set_status(f"Load failed: {exc}", tone="danger")
+            return False
+        if self.on_load is not None:
+            self.on_load(config_id, config)
+        self._set_status(
+            f'Loaded {self.conf_type.conftype} "{config_id}".',
+            tone="success",
+        )
+        return True
+
+    def save_current(self) -> bool:
+        config_id = self._save_id()
+        if not config_id:
+            self._set_status("Enter a configuration ID before saving.", tone="warning")
+            return False
+        try:
+            payload = self.build_save_payload(config_id)
+            self.conf_type.setID(config_id, payload)
+        except Exception as exc:
+            self._set_status(f"Save failed: {exc}", tone="danger")
+            return False
+        self.refresh_registry()
+        if self.on_save is not None:
+            self.on_save(config_id, payload)
+        self._set_status(
+            f'{self.conf_type.conftype} "{config_id}" saved to the registry.',
+            tone="success",
+        )
+        return True
+
+    def delete_selected(self) -> bool:
+        config_id = self._selected_id()
+        if not config_id:
+            self._set_status("Select a stored configuration to delete.", tone="warning")
+            return False
+        try:
+            self.conf_type.delete(config_id)
+        except Exception as exc:
+            self._set_status(f"Delete failed: {exc}", tone="danger")
+            return False
+        self.refresh_registry()
+        if self.on_delete is not None:
+            self.on_delete(config_id)
+        self._set_status(
+            f'{self.conf_type.conftype} "{config_id}" deleted from the registry.',
+            tone="success",
+        )
+        return True
+
+    def reset_store(self) -> bool:
+        try:
+            self.conf_type.reset(recreate=True)
+        except Exception as exc:
+            self._set_status(f"Reset failed: {exc}", tone="danger")
+            return False
+        self.refresh_registry()
+        if self.on_reset is not None:
+            self.on_reset(self._selected_id())
+        self._set_status(
+            f"{self.conf_type.conftype} registry recreated from the built-in defaults.",
+            tone="success",
+        )
+        return True
+
+    def request_reset(self) -> None:
+        if not self.confirm_reset:
+            self.reset_store()
+            return
+        confirm = pn.widgets.Button(
+            name="Yes, recreate store",
+            button_type="danger",
+            sizing_mode="stretch_width",
+        )
+        cancel = pn.widgets.Button(
+            name="No, cancel",
+            button_type="default",
+            sizing_mode="stretch_width",
+        )
+        message = pn.pane.HTML(
+            (
+                '<div style="font-size:12px;color:#9a3412;">'
+                f"This recreates the full {self.conf_type.conftype} registry store "
+                "from its default definitions."
+                "</div>"
+            ),
+            margin=(0, 0, 8, 0),
+        )
+
+        def _confirm(_event: Any = None) -> None:
+            self.reset_store()
+            self.reset_confirm_host.objects = []
+
+        def _cancel(_event: Any = None) -> None:
+            self.reset_confirm_host.objects = []
+            self._set_status("Reset cancelled.")
+
+        confirm.on_click(_confirm)
+        cancel.on_click(_cancel)
+        self.reset_confirm_host.objects = [
+            pn.Column(
+                message,
+                pn.Row(confirm, cancel, sizing_mode="stretch_width"),
+                sizing_mode="stretch_width",
+                margin=(0, 0, 8, 0),
+            )
+        ]
+
+
+def build_conftype_actions(
+    config_cls: type[param.Parameterized],
+    *,
+    conftype: str,
+    build_save_payload: Callable[[str], Any],
+    get_selected_id: Callable[[], str | None],
+    **kwargs: Any,
+) -> pn.Column:
+    controller = ConftypeActionsController(
+        config_cls,
+        conftype=conftype,
+        build_save_payload=build_save_payload,
+        get_selected_id=get_selected_id,
+        **kwargs,
+    )
+    return controller.view

--- a/src/larvaworld/portal/config_widgets/conftype_widget.py
+++ b/src/larvaworld/portal/config_widgets/conftype_widget.py
@@ -9,6 +9,10 @@ from larvaworld import CONFTYPES
 from larvaworld.lib import reg, util
 from larvaworld.lib.param.custom import ClassAttr, ClassDict
 from larvaworld.lib.param.nested_parameter_group import NestedConf
+from larvaworld.portal.config_widgets.conftype_actions import (
+    ConftypeActionsController,
+)
+from larvaworld.portal.config_widgets.enrichment_widget import build_enrichment_widget
 
 __all__ = [
     "ConftypeWidgetController",
@@ -157,7 +161,6 @@ class ConftypeWidgetController:
         self.allow_reset = allow_reset
         self.title = title or f"{self.conf_type.conftype} Configurations"
         self._editor_host = pn.Column(sizing_mode="stretch_width")
-        self._reset_confirm_host = pn.Column(sizing_mode="stretch_width")
         self._current = self._new_instance()
 
         self.header = pn.pane.Markdown(
@@ -184,36 +187,31 @@ class ConftypeWidgetController:
             options={},
             sizing_mode="stretch_width",
         )
-        self.load_button = pn.widgets.Button(
-            name="Load",
-            button_type="primary",
-            sizing_mode="stretch_width",
-        )
-        self.save_button = pn.widgets.Button(
-            name="Save",
-            button_type="primary",
-            sizing_mode="stretch_width",
-        )
-        self.delete_button = pn.widgets.Button(
-            name="Delete",
-            button_type="warning",
-            sizing_mode="stretch_width",
-        )
-        self.reset_button = pn.widgets.Button(
-            name="Reset configurations",
-            button_type="danger",
-            sizing_mode="stretch_width",
-            visible=allow_reset,
-        )
         self.status = pn.pane.HTML(
             '<div style="font-size:12px;color:#52606d;">Ready.</div>',
             margin=(8, 0, 8, 0),
         )
-
-        self.load_button.on_click(self._on_load)
-        self.save_button.on_click(self._on_save)
-        self.delete_button.on_click(self._on_delete)
-        self.reset_button.on_click(self._on_request_reset)
+        self.actions = ConftypeActionsController(
+            config_cls,
+            conftype=self.conf_type.conftype,
+            build_save_payload=lambda _config_id: _serialize_parameterized(
+                self._current
+            ),
+            get_selected_id=lambda: self.preset_select.value,
+            get_save_id=lambda: (
+                self.config_id_input.value.strip() or self.preset_select.value
+            ),
+            on_load=self._apply_loaded_config,
+            on_save=self._after_save,
+            on_delete=self._after_delete,
+            on_reset=self._after_reset,
+            on_status=self._set_status,
+            allow_reset=allow_reset,
+        )
+        self.load_button = self.actions.load_button
+        self.save_button = self.actions.save_button
+        self.delete_button = self.actions.delete_button
+        self.reset_button = self.actions.reset_button
         self.preset_select.param.watch(self._on_select_change, "value")
 
         self._refresh_preset_options()
@@ -224,18 +222,7 @@ class ConftypeWidgetController:
             self.meta,
             self.config_id_input,
             self.preset_select,
-            pn.Row(
-                self.load_button,
-                self.save_button,
-                self.delete_button,
-                sizing_mode="stretch_width",
-            ),
-            pn.Row(
-                self.reset_button,
-                sizing_mode="stretch_width",
-                visible=allow_reset,
-            ),
-            self._reset_confirm_host,
+            self.actions.view,
             self.status,
             self._editor_host,
             sizing_mode="stretch_width",
@@ -273,107 +260,33 @@ class ConftypeWidgetController:
         if event.new:
             self.config_id_input.value = str(event.new)
 
-    def _on_load(self, _event: Any = None) -> None:
-        config_id = self.preset_select.value
-        if not config_id:
-            self._set_status("Select a stored configuration to load.", tone="warning")
-            return
-        try:
-            self.conf_type.load()
-            self._current = self.conf_type.get(config_id)
-        except Exception as exc:
-            self._set_status(f"Load failed: {exc}", tone="danger")
-            return
-        self.config_id_input.value = str(config_id)
+    def _apply_loaded_config(self, _config_id: str, config: Any) -> None:
+        self._current = config
+        self.config_id_input.value = str(_config_id)
         self._render_editor()
-        self._set_status(
-            f'Loaded {self.conf_type.conftype} configuration "{config_id}".',
-            tone="success",
-        )
 
-    def _on_save(self, _event: Any = None) -> None:
-        config_id = self.config_id_input.value.strip() or self.preset_select.value
-        if not config_id:
-            self._set_status("Enter a configuration ID before saving.", tone="warning")
-            return
-        try:
-            payload = _serialize_parameterized(self._current)
-            self.conf_type.setID(config_id, payload)
-        except Exception as exc:
-            self._set_status(f"Save failed: {exc}", tone="danger")
-            return
+    def _after_save(self, config_id: str, _payload: Any) -> None:
         self._refresh_preset_options(select_id=config_id)
-        self._set_status(
-            f'Saved {self.conf_type.conftype} configuration "{config_id}".',
-            tone="success",
-        )
 
-    def _on_delete(self, _event: Any = None) -> None:
-        config_id = self.preset_select.value
-        if not config_id:
-            self._set_status("Select a stored configuration to delete.", tone="warning")
-            return
-        try:
-            self.conf_type.delete(config_id)
-        except Exception as exc:
-            self._set_status(f"Delete failed: {exc}", tone="danger")
-            return
+    def _after_delete(self, config_id: str) -> None:
         self._refresh_preset_options()
         if self.config_id_input.value == config_id:
             self.config_id_input.value = ""
-        self._set_status(
-            f'Deleted {self.conf_type.conftype} configuration "{config_id}".',
-            tone="success",
-        )
+
+    def _after_reset(self, selected_id: str | None) -> None:
+        self._refresh_preset_options(select_id=selected_id)
+
+    def _on_load(self, _event: Any = None) -> None:
+        self.actions.load_selected()
+
+    def _on_save(self, _event: Any = None) -> None:
+        self.actions.save_current()
+
+    def _on_delete(self, _event: Any = None) -> None:
+        self.actions.delete_selected()
 
     def _on_request_reset(self, _event: Any = None) -> None:
-        confirm = pn.widgets.Button(
-            name="Yes, recreate store",
-            button_type="danger",
-            sizing_mode="stretch_width",
-        )
-        cancel = pn.widgets.Button(
-            name="No, cancel",
-            button_type="default",
-            sizing_mode="stretch_width",
-        )
-        message = pn.pane.HTML(
-            (
-                '<div style="font-size:12px;color:#9a3412;">'
-                f"This recreates the full {self.conf_type.conftype} registry store "
-                "from its default definitions."
-                "</div>"
-            ),
-            margin=(0, 0, 8, 0),
-        )
-
-        def _confirm(_click: Any = None) -> None:
-            try:
-                self.conf_type.reset(recreate=True)
-            except Exception as exc:
-                self._set_status(f"Reset failed: {exc}", tone="danger")
-            else:
-                self._refresh_preset_options()
-                self._set_status(
-                    f"Recreated the {self.conf_type.conftype} registry store.",
-                    tone="success",
-                )
-            self._reset_confirm_host.objects = []
-
-        def _cancel(_click: Any = None) -> None:
-            self._reset_confirm_host.objects = []
-            self._set_status("Reset configurations cancelled.")
-
-        confirm.on_click(_confirm)
-        cancel.on_click(_cancel)
-        self._reset_confirm_host.objects = [
-            pn.Column(
-                message,
-                pn.Row(confirm, cancel, sizing_mode="stretch_width"),
-                sizing_mode="stretch_width",
-                margin=(0, 0, 8, 0),
-            )
-        ]
+        self.actions.request_reset()
 
     def _build_parameterized_section(
         self,
@@ -456,7 +369,12 @@ class ConftypeWidgetController:
             create_button.on_click(_create)
             content.append(create_button)
         else:
-            content.append(self._build_parameterized_section(nested_value, title=title))
+            if name == "enrichment":
+                content.append(build_enrichment_widget(nested_value, wrap=False))
+            else:
+                content.append(
+                    self._build_parameterized_section(nested_value, title=title)
+                )
 
         return pn.Card(
             content,

--- a/src/larvaworld/portal/config_widgets/enrichment_widget.py
+++ b/src/larvaworld/portal/config_widgets/enrichment_widget.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import panel as pn
+import param
+
+from .widget_base import classattr_section, collapsible_family_box, parameterized_editor
+
+__all__ = ["build_enrichment_widget", "build_preprocess_conf_widget"]
+
+
+def _ordered_names(instance: param.Parameterized, preferred: list[str]) -> list[str]:
+    return [name for name in preferred if name in instance.param and name != "name"]
+
+
+def build_preprocess_conf_widget(preprocess_conf: param.Parameterized) -> object:
+    return parameterized_editor(
+        preprocess_conf,
+        parameter_order=_ordered_names(
+            preprocess_conf,
+            [
+                "rescale_by",
+                "filter_f",
+                "transposition",
+                "interpolate_nans",
+                "drop_collisions",
+            ],
+        ),
+    )
+
+
+def build_enrichment_widget(
+    enrichment_conf: param.Parameterized,
+    *,
+    wrap: bool = True,
+) -> object:
+    children = [
+        classattr_section(
+            enrichment_conf,
+            name="pre_kws",
+            parameter=enrichment_conf.param["pre_kws"],
+            title="Preprocessing",
+            build_editor=build_preprocess_conf_widget,
+            box_css_classes=["lw-import-datasets-config-subfamily"],
+            title_css_classes=["lw-import-datasets-config-subfamily-title"],
+        ),
+        collapsible_family_box(
+            "Processing",
+            parameterized_editor(
+                enrichment_conf,
+                parameter_order=_ordered_names(
+                    enrichment_conf,
+                    [
+                        "proc_keys",
+                        "dsp_starts",
+                        "dsp_stops",
+                        "tor_durs",
+                        "anot_keys",
+                        "recompute",
+                        "mode",
+                    ],
+                ),
+                exclude={"pre_kws"},
+            ),
+            css_classes=[
+                "lw-import-datasets-config-subfamily-card",
+                "lw-import-datasets-config-compact-card",
+            ],
+        ),
+    ]
+    if not wrap:
+        return pn.Column(*children, sizing_mode="stretch_width", margin=0)
+    return collapsible_family_box("Enrichment", *children)

--- a/src/larvaworld/portal/datasets/import_datasets_app.py
+++ b/src/larvaworld/portal/datasets/import_datasets_app.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import panel as pn
 
 from larvaworld.lib import reg
-from larvaworld.portal.config_widgets import build_env_params_widget
+from larvaworld.lib.reg.generators import LabFormat
+from larvaworld.portal.config_widgets import (
+    ConftypeActionsController,
+    build_env_params_widget,
+)
 from larvaworld.portal.landing_registry import DOCS_DATA_PROCESSING
 from larvaworld.portal.datasets.discovery import (
     RawDatasetCandidate,
@@ -84,6 +88,11 @@ IMPORT_DATASETS_RAW_CSS = """
 
 .lw-import-datasets-source-row {
   gap: 0;
+  align-items: flex-end;
+}
+
+.lw-import-datasets-candidate-row {
+  gap: 10px;
   align-items: flex-end;
 }
 
@@ -285,6 +294,15 @@ def _config_family_box(title: str, *children: object) -> pn.Column:
     )
 
 
+def _half_width_row(child: object) -> pn.Row:
+    return pn.Row(
+        pn.Column(child, sizing_mode="stretch_width", margin=0),
+        pn.Spacer(sizing_mode="stretch_width"),
+        sizing_mode="stretch_width",
+        margin=0,
+    )
+
+
 class _ImportDatasetsController:
     def __init__(self) -> None:
         self.workspace = get_active_workspace()
@@ -304,26 +322,25 @@ class _ImportDatasetsController:
             name="Configuration ID",
             width=260,
         )
-        self.lab_load_button = pn.widgets.Button(
-            name="Load",
-            button_type="default",
-            width=90,
+        self.lab_actions = ConftypeActionsController(
+            LabFormat,
+            conftype="LabFormat",
+            build_save_payload=self._build_working_lab_conf,
+            get_selected_id=lambda: self.lab_select.value,
+            get_save_id=lambda: (
+                self.lab_config_name_input.value.strip() or self.lab_select.value
+            ),
+            on_load=self._apply_loaded_lab_config,
+            on_save=self._after_lab_save,
+            on_delete=self._after_lab_delete,
+            on_reset=self._after_lab_reset,
+            on_status=self._set_lab_status,
+            confirm_reset=False,
         )
-        self.lab_save_button = pn.widgets.Button(
-            name="Save",
-            button_type="primary",
-            width=90,
-        )
-        self.lab_delete_button = pn.widgets.Button(
-            name="Delete",
-            button_type="danger",
-            width=90,
-        )
-        self.lab_reset_button = pn.widgets.Button(
-            name="Reset",
-            button_type="default",
-            width=90,
-        )
+        self.lab_load_button = self.lab_actions.load_button
+        self.lab_save_button = self.lab_actions.save_button
+        self.lab_delete_button = self.lab_actions.delete_button
+        self.lab_reset_button = self.lab_actions.reset_button
         self.raw_root_input = pn.widgets.TextInput(
             name="Raw root",
             placeholder="/path/to/raw/data",
@@ -353,6 +370,11 @@ class _ImportDatasetsController:
             width=520,
         )
         self.candidate_select.description = "Select one discovered candidate to inspect its source path and warnings before importing it into the active workspace."
+        self.merged_checkbox = pn.widgets.Checkbox(
+            name="Merged",
+            value=False,
+            width=90,
+        )
         self.dataset_id_input = pn.widgets.TextInput(name="Dataset ID", width=260)
         self.group_id_input = pn.widgets.TextInput(
             name="Group ID override", placeholder="optional", width=260
@@ -368,21 +390,22 @@ class _ImportDatasetsController:
             button_type="primary",
             width=180,
         )
-        self.workspace_summary = pn.pane.HTML("", margin=0)
-        self.candidate_summary = pn.pane.HTML(
-            _candidate_summary_html(None), margin=(0, 0, 0, 0)
+        self.workspace_summary = pn.pane.HTML(
+            "", margin=(5, 10), sizing_mode="stretch_width"
         )
-        self.lab_status = pn.pane.HTML("", margin=0)
+        self.candidate_summary = pn.pane.HTML(
+            _candidate_summary_html(None),
+            margin=(5, 10),
+            sizing_mode="stretch_width",
+        )
+        self.lab_status = pn.pane.HTML("", margin=(5, 10), sizing_mode="stretch_width")
         self.lab_editor_sections = pn.Column(sizing_mode="stretch_width", margin=0)
-        self.status = pn.pane.HTML("", margin=0)
+        self.status = pn.pane.HTML("", margin=(5, 10), sizing_mode="stretch_width")
 
         self.lab_select.param.watch(self._on_lab_select_change, "value")
         self.raw_root_input.param.watch(self._on_raw_root_change, "value")
         self.candidate_select.param.watch(self._on_candidate_change, "value")
-        self.lab_load_button.on_click(self._handle_lab_load)
-        self.lab_save_button.on_click(self._handle_lab_save)
-        self.lab_delete_button.on_click(self._handle_lab_delete)
-        self.lab_reset_button.on_click(self._handle_lab_reset)
+        self.merged_checkbox.param.watch(self._on_merged_change, "value")
         self.browse_raw_root_button.on_click(self._handle_browse_raw_root)
         self.reset_button.on_click(self._handle_reset)
         self.discover_button.on_click(self._handle_discover)
@@ -668,13 +691,16 @@ class _ImportDatasetsController:
             self.lab_config_name_input.value = ""
             self._rebuild_lab_editor()
             return
-        self._working_lab_id = lab_id
-        self._working_lab = reg.conf.LabFormat.get(lab_id)
-        self.lab_config_name_input.value = lab_id
-        self._rebuild_lab_editor()
+        self._apply_loaded_lab_config(lab_id, reg.conf.LabFormat.get(lab_id))
         self._set_lab_status(f'Loaded LabFormat "{lab_id}".')
 
-    def _build_working_lab_conf(self):
+    def _apply_loaded_lab_config(self, lab_id: str, lab_config: object) -> None:
+        self._working_lab_id = lab_id
+        self._working_lab = lab_config
+        self.lab_config_name_input.value = lab_id
+        self._rebuild_lab_editor()
+
+    def _build_working_lab_conf(self, config_id: str | None = None):
         if self._working_lab_id is None:
             raise RuntimeError("No LabFormat configuration is loaded.")
         rebuilt = self._working_lab.nestedConf.get_copy()
@@ -692,9 +718,30 @@ class _ImportDatasetsController:
                     thermoscape.thermo_source_dTemps
                 )
             rebuilt["env_params"]["thermoscape"] = thermoscape_payload
-        target_id = self.lab_config_name_input.value.strip() or self._working_lab_id
+        target_id = config_id or self.lab_config_name_input.value.strip()
+        target_id = target_id or self._working_lab_id
         rebuilt["labID"] = target_id
         return rebuilt
+
+    def _after_lab_save(self, config_id: str, _payload: object) -> None:
+        self._refresh_lab_options(select_id=config_id)
+        self._load_working_lab(config_id)
+        self._refresh_workspace_summary()
+        self._sync_controls()
+
+    def _after_lab_delete(self, _config_id: str) -> None:
+        self._refresh_lab_options()
+        self._load_working_lab(self.lab_select.value)
+        self._clear_candidates()
+        self._refresh_workspace_summary()
+        self._sync_controls()
+
+    def _after_lab_reset(self, selected_lab_id: str | None) -> None:
+        self._refresh_lab_options(select_id=selected_lab_id)
+        self._load_working_lab(self.lab_select.value)
+        self._clear_candidates()
+        self._refresh_workspace_summary()
+        self._sync_controls()
 
     def _active_workspace_ready(self) -> bool:
         return self.workspace is not None
@@ -764,7 +811,9 @@ class _ImportDatasetsController:
         )
         candidate_ready = self._selected_candidate() is not None
         self.discover_button.disabled = not source_ready
-        self.candidate_select.disabled = not bool(self._candidate_by_key)
+        self.candidate_select.disabled = (
+            not bool(self._candidate_by_key) or self.merged_checkbox.value
+        )
         self.dataset_id_input.disabled = not candidate_ready
         self.group_id_input.disabled = not candidate_ready
         self.color_input.disabled = not candidate_ready
@@ -774,6 +823,7 @@ class _ImportDatasetsController:
         )
         self.raw_root_input.disabled = not workspace_ready
         self.browse_raw_root_button.disabled = not workspace_ready
+        self.merged_checkbox.disabled = not workspace_ready
         self.reset_button.disabled = not (
             workspace_ready and (self._raw_root_text() or self._candidate_by_key)
         )
@@ -817,77 +867,27 @@ class _ImportDatasetsController:
         )
         self._sync_controls()
 
+    def _on_merged_change(self, *_events) -> None:
+        self._sync_controls()
+
     def _handle_lab_load(self, _event=None) -> None:
-        self._load_working_lab(self.lab_select.value)
+        self.lab_actions.load_selected()
         self._sync_controls()
 
     def _handle_lab_save(self, _event=None) -> None:
-        config_id = self.lab_config_name_input.value.strip()
-        if not config_id:
-            self._set_lab_status(
-                "Enter a configuration ID before saving.", tone="warning"
-            )
-            return
-        try:
-            conf = self._build_working_lab_conf()
-            reg.conf.LabFormat.setID(config_id, conf)
-        except Exception as exc:
-            self._set_lab_status(str(exc), tone="danger")
-            return
-        self._refresh_lab_options(select_id=config_id)
-        self._load_working_lab(config_id)
-        self._set_lab_status(
-            f'LabFormat "{config_id}" saved to the registry.',
-            tone="success",
-        )
-        self._refresh_workspace_summary()
-        self._sync_controls()
+        self.lab_actions.save_current()
 
     def _handle_lab_delete(self, _event=None) -> None:
-        lab_id = self.lab_select.value
-        if not lab_id:
-            self._set_lab_status(
-                "Select a LabFormat configuration first.", tone="warning"
-            )
-            return
-        try:
-            reg.conf.LabFormat.delete(lab_id)
-        except Exception as exc:
-            self._set_lab_status(str(exc), tone="danger")
-            return
-        self._set_lab_status(
-            f'LabFormat "{lab_id}" deleted from the registry.',
-            tone="success",
-        )
-        self._refresh_lab_options()
-        self._load_working_lab(self.lab_select.value)
-        self._clear_candidates()
-        self._refresh_workspace_summary()
-        self._sync_controls()
+        self.lab_actions.delete_selected()
 
     def _handle_lab_reset(self, _event=None) -> None:
-        current_lab_id = self.lab_select.value
-        try:
-            reg.conf.LabFormat.reset(recreate=True)
-        except Exception as exc:
-            self._set_lab_status(
-                f"LabFormat registry reset failed: {exc}", tone="danger"
-            )
-            return
-        self._refresh_lab_options(select_id=current_lab_id)
-        self._load_working_lab(self.lab_select.value)
-        self._clear_candidates()
-        self._refresh_workspace_summary()
-        self._set_lab_status(
-            "LabFormat registry recreated from the built-in defaults.",
-            tone="success",
-        )
-        self._sync_controls()
+        self.lab_actions.reset_store()
 
     def _handle_reset(self, _event=None) -> None:
         self.raw_root_input.value = ""
         self.group_id_input.value = ""
         self.color_input.value = "#000000"
+        self.merged_checkbox.value = False
         self._clear_candidates()
         if self.workspace is not None:
             self._set_status(
@@ -965,6 +965,7 @@ class _ImportDatasetsController:
             raw_folder=raw_root,
             group_id=group_id,
             dataset_id=dataset_id,
+            merged=self.merged_checkbox.value,
             color=(self.color_input.value or "#000000"),
             extra_kwargs=extra_kwargs,
         )
@@ -993,57 +994,17 @@ class _ImportDatasetsController:
         self._sync_controls()
 
     def view(self) -> pn.viewable.Viewable:
-        config_section = pn.Card(
-            pn.Column(
-                pn.Column(
-                    self.lab_select,
-                    self.lab_config_name_input,
-                    sizing_mode="stretch_width",
-                    margin=0,
-                ),
-                pn.Column(
-                    pn.Row(
-                        self.lab_load_button,
-                        self.lab_save_button,
-                        css_classes=["lw-import-datasets-config-actions"],
-                        sizing_mode="stretch_width",
-                        margin=0,
-                    ),
-                    pn.Row(
-                        self.lab_delete_button,
-                        self.lab_reset_button,
-                        css_classes=["lw-import-datasets-config-actions"],
-                        sizing_mode="stretch_width",
-                        margin=0,
-                    ),
-                    sizing_mode="stretch_width",
-                    margin=(4, 0, 0, 0),
-                ),
-                self.lab_status,
-                self.lab_editor_sections,
-                sizing_mode="stretch_width",
-            ),
-            title="Lab Format Configuration",
-            collapsed=False,
-            sizing_mode="stretch_width",
-        )
         raw_root_row = pn.Row(
             self.raw_root_input,
             self.browse_raw_root_button,
             css_classes=["lw-import-datasets-source-row"],
             sizing_mode="stretch_width",
         )
-        source_section = _flow_section(
-            "Source",
-            self.lab_select,
-            raw_root_row,
-            self.discover_button,
-            self.status,
-        )
-        discovery_section = _flow_section(
-            "Discovery",
+        candidate_row = pn.Row(
             self.candidate_select,
-            self.candidate_summary,
+            self.merged_checkbox,
+            css_classes=["lw-import-datasets-candidate-row"],
+            sizing_mode="stretch_width",
         )
         import_section = _flow_section(
             "Import Options",
@@ -1063,16 +1024,37 @@ class _ImportDatasetsController:
                 sizing_mode="stretch_width",
             ),
             pn.Spacer(height=8),
-            self.workspace_summary,
+            _half_width_row(self.workspace_summary),
         )
-        workflow_section = pn.Card(
+        config_section = pn.Card(
             pn.Column(
-                source_section,
-                discovery_section,
+                pn.Column(
+                    self.lab_select,
+                    self.lab_config_name_input,
+                    sizing_mode="stretch_width",
+                    margin=0,
+                ),
+                raw_root_row,
+                self.discover_button,
+                candidate_row,
+                _half_width_row(self.candidate_summary),
+                _half_width_row(self.status),
+                _half_width_row(self.lab_status),
+                pn.Row(
+                    pn.Column(
+                        self.lab_actions.view,
+                        sizing_mode="stretch_width",
+                        margin=0,
+                    ),
+                    pn.Spacer(sizing_mode="stretch_width"),
+                    sizing_mode="stretch_width",
+                    margin=0,
+                ),
                 import_section,
+                self.lab_editor_sections,
                 sizing_mode="stretch_width",
             ),
-            title="Import Workflow",
+            title="Lab Format Configuration",
             collapsed=False,
             sizing_mode="stretch_width",
         )
@@ -1081,7 +1063,7 @@ class _ImportDatasetsController:
                 '<div class="lw-import-datasets-intro">'
                 "Import one experimental raw dataset into the active workspace through a small workspace-first pipeline, while editing the active `LabFormat` configuration in place before discovery and import. "
                 "The configuration panel exposes the registry-backed general, tracker, filesystem, preprocess, and environment sections used by the import lane, so the selected preset can be adjusted without leaving the app. "
-                "Then use the Source and Discovery steps to point the app at a local raw-data folder, resolve one import candidate, inspect warnings, and import the dataset into workspace-owned storage through the central Larvaworld backend. "
+                "Use the raw-root and candidate controls in the configuration panel to point the app at a local raw-data folder, resolve one import candidate, inspect warnings, and import the dataset into workspace-owned storage through the central Larvaworld backend. "
                 "The app does not register references or set global active-dataset state. "
                 f'See the data-processing documentation on Read the Docs for the broader dataset pipeline: <a href="{escape(DOCS_DATA_PROCESSING)}" target="_blank">Read the Docs</a>.'
                 "</div>"
@@ -1091,7 +1073,6 @@ class _ImportDatasetsController:
         return pn.Column(
             intro,
             config_section,
-            workflow_section,
             css_classes=["lw-import-datasets-root"],
             sizing_mode="stretch_width",
         )

--- a/src/larvaworld/portal/serve.py
+++ b/src/larvaworld/portal/serve.py
@@ -21,7 +21,7 @@ APP_ID_TO_FACTORY_PATH: dict[str, str] = {
     "loading": "larvaworld.portal.serve:loading_app",
     "landing": "larvaworld.portal.landing_app:landing_app",
     "notebook": "larvaworld.portal.notebook_launch_app:notebook_launch_app",
-    "wf.run_experiment": "larvaworld.portal.single_experiment_app:single_experiment_app",
+    "wf.run_experiment": "larvaworld.portal.simulation.single_experiment_app:single_experiment_app",
     "wf.open_dataset": "larvaworld.portal.datasets.import_datasets_app:import_datasets_app",
     "wf.dataset_manager": "larvaworld.portal.datasets.dataset_manager_app:dataset_manager_app",
     "wf.environment_builder": "larvaworld.portal.models_architecture.environment_builder_app:environment_builder_app",

--- a/src/larvaworld/portal/simulation/__init__.py
+++ b/src/larvaworld/portal/simulation/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/larvaworld/portal/simulation/preview_frames.py
+++ b/src/larvaworld/portal/simulation/preview_frames.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from math import isfinite, nan
+from typing import Any
+
+from larvaworld.portal.canvas_widgets.environment_models import LarvaPreviewFrame
+
+_INVALID_XY: tuple[float, float] = (nan, nan)
+
+
+def _copy_xy(value: Any) -> tuple[float, float] | None:
+    try:
+        x_raw = value[0]
+        y_raw = value[1]
+    except (TypeError, IndexError, KeyError):
+        return None
+    try:
+        x = float(x_raw)
+        y = float(y_raw)
+    except (TypeError, ValueError):
+        return None
+    if not (isfinite(x) and isfinite(y)):
+        return None
+    return (x, y)
+
+
+def _copy_path(value: Any) -> tuple[tuple[float, float], ...]:
+    try:
+        iterator = iter(value)
+    except TypeError:
+        return ()
+    points: list[tuple[float, float]] = []
+    for candidate in iterator:
+        xy = _copy_xy(candidate)
+        if xy is not None:
+            points.append(xy)
+    return tuple(points)
+
+
+def _copy_positions(values: Any, count: int) -> tuple[tuple[float, float], ...]:
+    copied: list[tuple[float, float]] = []
+    for index in range(count):
+        point = None
+        try:
+            point = _copy_xy(values[index])
+        except (TypeError, IndexError, KeyError):
+            point = None
+        copied.append(point if point is not None else _INVALID_XY)
+    return tuple(copied)
+
+
+def capture_larva_frame(
+    launcher: Any,
+    *,
+    tick: int | None = None,
+    trail_length: int = 30,
+    include_heads: bool = True,
+    include_midlines: bool = True,
+    include_trails: bool = True,
+) -> LarvaPreviewFrame:
+    agents = launcher.agents
+    n_agents = len(agents)
+    centroids = _copy_positions(agents.get_position(), n_agents)
+
+    heads: tuple[tuple[float, float], ...] = ()
+    if include_heads:
+        raw_heads = agents.head.front_end
+        head_rows: list[tuple[float, float]] = []
+        for index in range(n_agents):
+            point = None
+            try:
+                point = _copy_xy(raw_heads[index])
+            except (TypeError, IndexError, KeyError):
+                point = None
+            head_rows.append(point if point is not None else _INVALID_XY)
+        heads = tuple(head_rows)
+
+    midlines: tuple[tuple[tuple[float, float], ...], ...] = ()
+    if include_midlines:
+        midline_rows: list[tuple[tuple[float, float], ...]] = []
+        for index in range(n_agents):
+            path: tuple[tuple[float, float], ...] = ()
+            try:
+                path = _copy_path(agents[index].midline_xy)
+            except (TypeError, IndexError, KeyError, AttributeError):
+                path = ()
+            midline_rows.append(path)
+        midlines = tuple(midline_rows)
+
+    trails: tuple[tuple[tuple[float, float], ...], ...] = ()
+    if include_trails:
+        trail_rows: list[tuple[tuple[float, float], ...]] = []
+        for index in range(n_agents):
+            path: tuple[tuple[float, float], ...] = ()
+            try:
+                trajectory = agents[index].trajectory
+                path = _copy_path(trajectory[-trail_length:])
+            except (TypeError, IndexError, KeyError, AttributeError):
+                path = ()
+            trail_rows.append(path)
+        trails = tuple(trail_rows)
+
+    colors = tuple(
+        "" if getattr(agent, "color", None) is None else str(agent.color)
+        for agent in agents
+    )
+
+    resolved_tick = launcher.t if tick is None else tick
+    return LarvaPreviewFrame(
+        tick=int(resolved_tick),
+        centroids=centroids,
+        heads=heads,
+        midlines=midlines,
+        trails=trails,
+        colors=colors,
+    )
+
+
+def generate_preview_frames(
+    launcher: Any,
+    *,
+    preview_steps: int,
+    trail_length: int = 30,
+    include_heads: bool = True,
+    include_midlines: bool = True,
+    include_trails: bool = True,
+) -> list[LarvaPreviewFrame]:
+    if preview_steps <= 0:
+        return []
+
+    frames: list[LarvaPreviewFrame] = []
+    for index in range(preview_steps):
+        frames.append(
+            capture_larva_frame(
+                launcher,
+                trail_length=trail_length,
+                include_heads=include_heads,
+                include_midlines=include_midlines,
+                include_trails=include_trails,
+            )
+        )
+        if index < preview_steps - 1:
+            launcher.sim_step()
+    return frames

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -17,6 +17,7 @@ from larvaworld.lib import reg, screen, sim, util
 from larvaworld.lib.param.custom import ClassAttr, ClassDict
 from larvaworld.portal.canvas_widgets import (
     EnvironmentCanvas,
+    LarvaPreviewFrame,
     env_params_to_canvas_state,
 )
 from larvaworld.portal.landing_registry import (
@@ -24,6 +25,7 @@ from larvaworld.portal.landing_registry import (
     DOCS_SINGLE_EXPERIMENTS,
 )
 from larvaworld.portal.panel_components import PORTAL_RAW_CSS, build_app_header
+from larvaworld.portal.simulation.preview_frames import generate_preview_frames
 from larvaworld.portal.workspace import WorkspaceError, get_workspace_dir
 
 
@@ -839,6 +841,62 @@ class _ExperimentPreview:
         )
 
 
+class _FrameSimulationPreview:
+    def __init__(
+        self,
+        *,
+        canvas: EnvironmentCanvas,
+        frames: list[LarvaPreviewFrame],
+        dt: float,
+    ) -> None:
+        if not frames:
+            raise ValueError("frames must not be empty")
+        self.canvas = canvas
+        self.frames = list(frames)
+        self.dt = max(0.0, float(dt))
+        self.frame_slider = pn.widgets.IntSlider(
+            name="Frame",
+            start=0,
+            end=len(self.frames) - 1,
+            value=0,
+            step=1,
+            width=320,
+        )
+        self.metadata = pn.pane.HTML("", sizing_mode="stretch_width")
+        self.frame_slider.param.watch(self._on_frame_change, "value")
+        self._apply_frame(0)
+
+    def _set_metadata(self, index: int) -> None:
+        frame = self.frames[index]
+        end_index = len(self.frames) - 1
+        timestamp = frame.tick * self.dt
+        end_time = self.frames[-1].tick * self.dt
+        self.metadata.object = (
+            '<div class="lw-single-exp-preview-meta">'
+            f"<strong>Frame:</strong> {index}/{end_index}; "
+            f"<strong>Tick:</strong> {frame.tick}; "
+            f"<strong>Time:</strong> {timestamp:.1f} s; "
+            f"<strong>Displayed range:</strong> 0.0-{end_time:.1f} s."
+            "</div>"
+        )
+
+    def _apply_frame(self, index: int) -> None:
+        clamped = max(0, min(index, len(self.frames) - 1))
+        self.canvas.set_larva_frame(self.frames[clamped])
+        self._set_metadata(clamped)
+
+    def _on_frame_change(self, event: Any) -> None:
+        self._apply_frame(int(event.new))
+
+    def view(self) -> pn.viewable.Viewable:
+        return pn.Column(
+            self.canvas.view(),
+            pn.Row(pn.Column("Frame", self.frame_slider), sizing_mode="stretch_width"),
+            self.metadata,
+            sizing_mode="stretch_width",
+        )
+
+
 class _SingleExperimentController:
     def __init__(self) -> None:
         experiment_ids = list(reg.conf.Exp.confIDs)
@@ -1091,6 +1149,9 @@ class _SingleExperimentController:
             flat[path] = self._parse_widget_value(kind, widget)
         flat = self._apply_optional_family_states(flat)
         return util.AttrDict(_coerce_xy_sequences(util.AttrDict(flat.unflatten())))
+
+    def _resolve_experiment_parameters(self) -> util.AttrDict:
+        return self._build_parameters()
 
     def _refresh_environment_options(self) -> None:
         try:
@@ -2092,7 +2153,7 @@ class _SingleExperimentController:
 
     def _on_prepare_preview(self, *_: object) -> None:
         try:
-            parameters = self._build_parameters()
+            parameters = self._resolve_experiment_parameters()
             run_dir = self._build_run_directory()
         except (WorkspaceError, OSError, json.JSONDecodeError) as exc:
             self.status.object = f"Cannot prepare the configuration preview: {exc}"
@@ -2135,7 +2196,7 @@ class _SingleExperimentController:
 
     def _on_generate_simulation_preview(self, *_: object) -> None:
         try:
-            parameters = self._build_parameters()
+            parameters = self._resolve_experiment_parameters()
             run_dir = self._build_run_directory()
         except (WorkspaceError, OSError, json.JSONDecodeError) as exc:
             self.status.object = f"Cannot generate the simulation preview: {exc}"
@@ -2155,13 +2216,32 @@ class _SingleExperimentController:
         ]
         self.status.object = f'Generating simulation preview for "{self.experiment.value}" using {selected_env}.'
         self._set_run_controls_disabled(True)
+        launcher = None
         try:
             launcher, fallback_note = self._prepare_preview_launcher(
                 self.experiment.value,
                 parameters,
                 run_dir,
             )
-            preview = _ExperimentPreview(launcher, launcher_ready=True).view()
+            preview_steps = max(1, min(int(launcher.p.steps), _PREVIEW_STEP_CAP))
+            frames = generate_preview_frames(
+                launcher,
+                preview_steps=preview_steps,
+            )
+            if not frames:
+                raise ValueError("No preview frames were generated.")
+            state = env_params_to_canvas_state(
+                parameters.env_params,
+                larva_groups=parameters.get("larva_groups", {}),
+                show_group_shapes=False,
+            )
+            canvas = EnvironmentCanvas(editable=False)
+            canvas.set_state(state)
+            preview = _FrameSimulationPreview(
+                canvas=canvas,
+                frames=frames,
+                dt=float(launcher.dt),
+            ).view()
         except Exception as exc:
             self.preview_meta.object = ""
             self.preview[:] = [
@@ -2177,13 +2257,22 @@ class _SingleExperimentController:
             self.status.object = f"Cannot generate the simulation preview: {exc}"
             self._set_run_controls_disabled(False)
             return
+        finally:
+            try:
+                if launcher is not None and getattr(launcher, "screen_manager", None):
+                    launcher.screen_manager.close()
+            except Exception:
+                pass
 
         self.preview_meta.object = self._preview_metadata_html(parameters, selected_env)
         self.preview[:] = [preview]
+        displayed_end = frames[-1].tick * float(launcher.dt)
         status = (
             f'Generated simulation preview for "{self.experiment.value}" using {selected_env}. '
             f"Reserved output directory for a future run: <code>{run_dir}</code>. "
-            "The interactive preview is capped to the first 300 steps for responsiveness."
+            f"Simulation preview ready: {len(frames)} frames generated. "
+            f"Displayed range: 0.0-{displayed_end:.1f} s simulated time. "
+            "Generated from the actual simulation engine. Outputs are not stored; use Run experiment for the full run."
         )
         if fallback_note:
             status = f"{status} {fallback_note}"
@@ -2192,7 +2281,7 @@ class _SingleExperimentController:
 
     def _on_run_experiment(self, *_: object) -> None:
         try:
-            parameters = self._build_parameters()
+            parameters = self._resolve_experiment_parameters()
             run_dir = self._build_run_directory()
         except (WorkspaceError, OSError, json.JSONDecodeError) as exc:
             self.status.object = f"Cannot start the single experiment run: {exc}"

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -854,17 +854,20 @@ class _FrameSimulationPreview:
         self.canvas = canvas
         self.frames = list(frames)
         self.dt = max(0.0, float(dt))
-        self.frame_slider = pn.widgets.IntSlider(
+        self.frame_player = pn.widgets.Player(
             name="Frame",
             start=0,
             end=len(self.frames) - 1,
             value=0,
             step=1,
-            width=320,
+            interval=max(50, min(1000, int(self.dt * 1000))),
+            loop_policy="once",
+            show_loop_controls=False,
+            width=420,
         )
         self.metadata = pn.pane.HTML("", sizing_mode="stretch_width")
-        self.frame_slider.param.watch(self._on_frame_change, "value")
-        self._apply_frame(0)
+        self.frame_player.param.watch(self._on_player_change, "value")
+        self._show_frame(0)
 
     def _set_metadata(self, index: int) -> None:
         frame = self.frames[index]
@@ -880,18 +883,21 @@ class _FrameSimulationPreview:
             "</div>"
         )
 
-    def _apply_frame(self, index: int) -> None:
+    def _show_frame(self, index: int) -> None:
         clamped = max(0, min(index, len(self.frames) - 1))
+        if int(self.frame_player.value) != clamped:
+            self.frame_player.value = clamped
+            return
         self.canvas.set_larva_frame(self.frames[clamped])
         self._set_metadata(clamped)
 
-    def _on_frame_change(self, event: Any) -> None:
-        self._apply_frame(int(event.new))
+    def _on_player_change(self, event: Any) -> None:
+        self._show_frame(int(event.new))
 
     def view(self) -> pn.viewable.Viewable:
         return pn.Column(
             self.canvas.view(),
-            pn.Row(pn.Column("Frame", self.frame_slider), sizing_mode="stretch_width"),
+            pn.Row(pn.Column("Frame", self.frame_player), sizing_mode="stretch_width"),
             self.metadata,
             sizing_mode="stretch_width",
         )
@@ -931,6 +937,13 @@ class _SingleExperimentController:
             name="Run experiment",
             button_type="success",
         )
+        self.preview_frames_input = pn.widgets.IntInput(
+            name="Preview frames",
+            value=_PREVIEW_STEP_CAP,
+            start=1,
+            end=1000,
+            step=50,
+        )
         self.save_video = pn.widgets.Checkbox(name="Save video", value=False)
         self.video_filename = pn.widgets.TextInput(
             name="Video filename",
@@ -952,6 +965,28 @@ class _SingleExperimentController:
         self.simulation_preview_btn.sizing_mode = "stretch_width"
         self.run_btn.width = None
         self.run_btn.sizing_mode = "stretch_width"
+        self.preview_frames_input.width = None
+        self.preview_frames_input.sizing_mode = "stretch_width"
+        self.preview_action_row = pn.Row(
+            self.prepare_btn,
+            sizing_mode="stretch_width",
+            margin=0,
+        )
+        self.preview_options_row = pn.Row(
+            self.preview_frames_input,
+            sizing_mode="stretch_width",
+            margin=0,
+        )
+        self.preview_generate_row = pn.Row(
+            self.simulation_preview_btn,
+            sizing_mode="stretch_width",
+            margin=(4, 0, 0, 0),
+        )
+        self.execution_action_row = pn.Row(
+            self.run_btn,
+            sizing_mode="stretch_width",
+            margin=(6, 0, 0, 0),
+        )
         self.summary = pn.pane.HTML(
             "", sizing_mode="stretch_width", margin=(0, 0, 4, 0)
         )
@@ -2028,6 +2063,7 @@ class _SingleExperimentController:
         self.prepare_btn.disabled = disabled
         self.simulation_preview_btn.disabled = disabled
         self.run_btn.disabled = disabled
+        self.preview_frames_input.disabled = disabled
         self.refresh_environments_btn.disabled = disabled
 
     def _execute_run_experiment(
@@ -2223,7 +2259,8 @@ class _SingleExperimentController:
                 parameters,
                 run_dir,
             )
-            preview_steps = max(1, min(int(launcher.p.steps), _PREVIEW_STEP_CAP))
+            requested_steps = int(self.preview_frames_input.value)
+            preview_steps = max(1, min(requested_steps, int(launcher.p.steps)))
             frames = generate_preview_frames(
                 launcher,
                 preview_steps=preview_steps,
@@ -2353,13 +2390,10 @@ class _SingleExperimentController:
                 self.refresh_environments_btn,
                 media_controls,
                 self.summary,
-                pn.Row(
-                    self.prepare_btn,
-                    self.simulation_preview_btn,
-                    self.run_btn,
-                    sizing_mode="stretch_width",
-                    margin=0,
-                ),
+                self.preview_action_row,
+                self.preview_options_row,
+                self.preview_generate_row,
+                self.execution_action_row,
                 self.status,
                 sizing_mode="stretch_width",
                 margin=0,

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -2104,6 +2104,7 @@ class _SingleExperimentController:
             state = env_params_to_canvas_state(
                 parameters.env_params,
                 larva_groups=parameters.get("larva_groups", {}),
+                show_group_shapes=False,
             )
             canvas = EnvironmentCanvas(editable=False)
             canvas.set_state(state)

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -620,6 +620,10 @@ def _join_help_parts(*parts: str | None) -> str | None:
 
 
 class _ExperimentPreview:
+    _FORWARD_ONLY_MESSAGE = (
+        "Preview is forward-only; prepare the preview again to replay from the start."
+    )
+
     def __init__(
         self,
         launcher: sim.ExpRun,
@@ -653,15 +657,18 @@ class _ExperimentPreview:
             max=self.launcher.Nsteps - 1,
             value=self.launcher.t,
         )
-        self.time_slider = pn.widgets.Player(
+        self.time_slider = pn.widgets.IntSlider(
             name="Tick",
             width=int(self.size / 2),
             start=0,
             end=preview_steps - 1,
-            interval=max(int(1000 * self.launcher.dt), 1),
+            step=1,
             value=0,
         )
+        self.forward_only_note = pn.pane.HTML("", sizing_mode="stretch_width")
+        self._syncing_slider = False
         self.tank_plot = self._get_tank_plot()
+        self.static_overlay = self._build_static_overlay()
 
     def _get_tank_plot(self) -> hv.element.Overlay:
         arena = self.env.arena
@@ -723,68 +730,104 @@ class _ExperimentPreview:
                 )
         return border_layers
 
-    def _draw_overlay(self) -> hv.Overlay:
+    def _build_static_overlay(self) -> hv.Overlay:
+        return hv.Overlay(
+            [self.tank_plot]
+            + self._odor_layers()
+            + self._source_layers()
+            + self._border_layers()
+        )
+
+    def _dynamic_agent_layers(self) -> list[Any]:
         agents = self.launcher.agents
-        draw_layers = util.AttrDict(
-            {
-                "draw_segs": hv.Overlay(
+        layers = []
+        if self.draw_ops.draw_segs:
+            layers.append(
+                hv.Overlay(
                     [
                         hv.Polygons([seg.vertices for seg in agent.segs]).opts(
                             color=agent.color
                         )
                         for agent in agents
                     ]
-                ),
-                "draw_centroid": hv.Points(agents.get_position()).opts(
+                )
+            )
+        if self.draw_ops.draw_centroid:
+            layers.append(
+                hv.Points(agents.get_position()).opts(
                     size=5,
                     color="black",
-                ),
-                "draw_head": hv.Points(agents.head.front_end).opts(
+                )
+            )
+        if self.draw_ops.draw_head:
+            layers.append(
+                hv.Points(agents.head.front_end).opts(
                     size=5,
                     color="red",
-                ),
-                "draw_midline": hv.Overlay(
+                )
+            )
+        if self.draw_ops.draw_midline:
+            layers.append(
+                hv.Overlay(
                     [
                         hv.Path(agent.midline_xy).opts(color="blue", line_width=2)
                         for agent in agents
                     ]
-                ),
-                "visible_trails": hv.Contours(
-                    [agent.trajectory[-self.Nfade :] for agent in agents]
-                ).opts(color="black"),
-            }
-        )
-        source_layers = self._source_layers()
-        odor_layers = self._odor_layers()
-        border_layers = self._border_layers()
-        agent_layers = [
-            layer for key, layer in draw_layers.items() if getattr(self.draw_ops, key)
-        ]
-        return hv.Overlay(
-            [self.tank_plot]
-            + odor_layers
-            + source_layers
-            + border_layers
-            + agent_layers
-        ).opts(
+                )
+            )
+        if self.draw_ops.visible_trails:
+            layers.append(
+                hv.Contours([agent.trajectory[-self.Nfade :] for agent in agents]).opts(
+                    color="black"
+                )
+            )
+        return layers
+
+    def _draw_overlay(self) -> hv.Overlay:
+        agent_layers = self._dynamic_agent_layers()
+        overlay = self.static_overlay
+        if agent_layers:
+            overlay = overlay * hv.Overlay(agent_layers)
+        return overlay.opts(
             responsive=False,
             **self.image_kws,
         )
 
+    def _sync_slider_to_current_tick(self) -> None:
+        self._syncing_slider = True
+        try:
+            self.time_slider.value = self.launcher.t
+        finally:
+            self._syncing_slider = False
+
+    def _image_for_tick(self, i: int) -> hv.Overlay:
+        if self._syncing_slider:
+            return self._draw_overlay()
+        if i < self.launcher.t:
+            self.forward_only_note.object = self._FORWARD_ONLY_MESSAGE
+            self._sync_slider_to_current_tick()
+            self.progress_bar.value = self.launcher.t
+            return self._draw_overlay()
+        self.forward_only_note.object = ""
+        if i == self.launcher.t:
+            return self._draw_overlay()
+        while i > self.launcher.t:
+            self.launcher.sim_step()
+        self.progress_bar.value = self.launcher.t
+        return self._draw_overlay()
+
     def view(self) -> pn.viewable.Viewable:
         @pn.depends(i=self.time_slider)
         def _image(i: int) -> hv.Overlay:
-            while i > self.launcher.t:
-                self.launcher.sim_step()
-                self.progress_bar.value = self.launcher.t
-            return self._draw_overlay()
+            return self._image_for_tick(i)
 
         preview = hv.DynamicMap(_image)
         return pn.Row(
             preview,
             pn.Column(
                 pn.Row(pn.Column("Tick", self.time_slider)),
-                pn.Row(pn.Column("Simulation timestep", self.progress_bar)),
+                pn.Row(pn.Column("Computed timestep", self.progress_bar)),
+                self.forward_only_note,
                 pn.Param(self.draw_ops),
             ),
             sizing_mode="stretch_width",

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -15,6 +15,10 @@ import param
 
 from larvaworld.lib import reg, screen, sim, util
 from larvaworld.lib.param.custom import ClassAttr, ClassDict
+from larvaworld.portal.canvas_widgets import (
+    EnvironmentCanvas,
+    env_params_to_canvas_state,
+)
 from larvaworld.portal.landing_registry import (
     DOCS_EXPERIMENT_TYPES,
     DOCS_SINGLE_EXPERIMENTS,
@@ -152,6 +156,7 @@ _ENRICHMENT_ANOT_KEY_OPTIONS = [
 ]
 _ODORSCAPE_OPTIONS = ["Analytical", "Gaussian", "Diffusion"]
 _PREVIEW_STEP_CAP = 300
+_REGISTRY_ENV_PRESET_PREFIX = "__registry__:"
 _NONE_OPTION_LABEL = "None"
 
 
@@ -857,8 +862,12 @@ class _SingleExperimentController:
             button_type="default",
         )
         self.prepare_btn = pn.widgets.Button(
-            name="Prepare preview",
+            name="Prepare configuration preview",
             button_type="primary",
+        )
+        self.simulation_preview_btn = pn.widgets.Button(
+            name="Generate simulation preview",
+            button_type="default",
         )
         self.run_btn = pn.widgets.Button(
             name="Run experiment",
@@ -881,6 +890,8 @@ class _SingleExperimentController:
         self.show_display = pn.widgets.Checkbox(name="Show display", value=False)
         self.prepare_btn.width = None
         self.prepare_btn.sizing_mode = "stretch_width"
+        self.simulation_preview_btn.width = None
+        self.simulation_preview_btn.sizing_mode = "stretch_width"
         self.run_btn.width = None
         self.run_btn.sizing_mode = "stretch_width"
         self.summary = pn.pane.HTML(
@@ -938,7 +949,7 @@ class _SingleExperimentController:
                 (
                     '<div class="lw-single-exp-preview-placeholder">'
                     "Choose an experiment template, optionally apply a workspace environment preset, "
-                    "and prepare the simulation preview here."
+                    "and prepare the configuration preview here."
                     "</div>"
                 ),
                 margin=0,
@@ -953,6 +964,7 @@ class _SingleExperimentController:
         self.save_video.param.watch(self._on_save_video_change, "value")
         self.refresh_environments_btn.on_click(self._on_refresh_environments)
         self.prepare_btn.on_click(self._on_prepare_preview)
+        self.simulation_preview_btn.on_click(self._on_generate_simulation_preview)
         self.run_btn.on_click(self._on_run_experiment)
 
         self._refresh_environment_options()
@@ -970,17 +982,39 @@ class _SingleExperimentController:
         options = {"Template default environment": "__template__"}
         preset_dir = self._environment_dir()
         preset_dir.mkdir(parents=True, exist_ok=True)
+        workspace_labels: set[str] = set()
         for path in sorted(preset_dir.glob("*.json")):
+            workspace_labels.add(path.stem)
             options[path.stem] = path.name
+        registry_options = {
+            f"Registry / {name}": f"{_REGISTRY_ENV_PRESET_PREFIX}{name}"
+            for name in sorted(str(key) for key in reg.conf.Env.dict.keys())
+            if name not in workspace_labels
+        }
+        options.update(registry_options)
         return options
 
     def _load_selected_environment(self) -> util.AttrDict | None:
         selected = self.environment_select.value
         if selected in {None, "", "__template__"}:
             return None
+        if str(selected).startswith(_REGISTRY_ENV_PRESET_PREFIX):
+            registry_id = str(selected)[len(_REGISTRY_ENV_PRESET_PREFIX) :]
+            return util.AttrDict(reg.conf.Env.getID(registry_id)).get_copy()
         preset_path = self._environment_dir() / str(selected)
         payload = json.loads(preset_path.read_text(encoding="utf-8"))
         return util.AttrDict(payload)
+
+    def _selected_environment_label(self) -> str:
+        selected = self.environment_select.value
+        if selected == "__template__":
+            return "template default"
+        if selected is not None and str(selected).startswith(
+            _REGISTRY_ENV_PRESET_PREFIX
+        ):
+            registry_id = str(selected)[len(_REGISTRY_ENV_PRESET_PREFIX) :]
+            return f"registry / {registry_id}"
+        return str(selected)
 
     @staticmethod
     def _apply_environment_payload(
@@ -1931,6 +1965,7 @@ class _SingleExperimentController:
 
     def _set_run_controls_disabled(self, disabled: bool) -> None:
         self.prepare_btn.disabled = disabled
+        self.simulation_preview_btn.disabled = disabled
         self.run_btn.disabled = disabled
         self.refresh_environments_btn.disabled = disabled
 
@@ -2060,30 +2095,65 @@ class _SingleExperimentController:
             parameters = self._build_parameters()
             run_dir = self._build_run_directory()
         except (WorkspaceError, OSError, json.JSONDecodeError) as exc:
-            self.status.object = f"Cannot prepare the single experiment preview: {exc}"
+            self.status.object = f"Cannot prepare the configuration preview: {exc}"
             return
 
-        selected_env = (
-            "template default"
-            if self.environment_select.value == "__template__"
-            else str(self.environment_select.value)
+        selected_env = self._selected_environment_label()
+        self._set_run_controls_disabled(True)
+        try:
+            state = env_params_to_canvas_state(
+                parameters.env_params,
+                larva_groups=parameters.get("larva_groups", {}),
+            )
+            canvas = EnvironmentCanvas(editable=False)
+            canvas.set_state(state)
+        except Exception as exc:
+            self.preview_meta.object = ""
+            self.preview[:] = [
+                pn.pane.HTML(
+                    (
+                        '<div class="lw-single-exp-preview-placeholder">'
+                        f"Configuration preview failed: {exc}"
+                        "</div>"
+                    ),
+                    margin=0,
+                )
+            ]
+            self.status.object = f"Cannot prepare the configuration preview: {exc}"
+            self._set_run_controls_disabled(False)
+            return
+
+        self.preview_meta.object = self._preview_metadata_html(parameters, selected_env)
+        self.preview[:] = [canvas.view()]
+        self.status.object = (
+            f'Prepared configuration preview for "{self.experiment.value}" using '
+            f"{selected_env}. Reserved output directory for a future run: "
+            f"<code>{run_dir}</code>. No simulation has been run."
         )
+        self._set_run_controls_disabled(False)
+
+    def _on_generate_simulation_preview(self, *_: object) -> None:
+        try:
+            parameters = self._build_parameters()
+            run_dir = self._build_run_directory()
+        except (WorkspaceError, OSError, json.JSONDecodeError) as exc:
+            self.status.object = f"Cannot generate the simulation preview: {exc}"
+            return
+
+        selected_env = self._selected_environment_label()
         self.preview_meta.object = self._preview_metadata_html(parameters, selected_env)
         self.preview[:] = [
             pn.pane.HTML(
                 (
                     '<div class="lw-single-exp-preview-placeholder">'
-                    "Preparing preview. The simulation environment and agents are being initialized."
+                    "Generating simulation preview. The environment and agents are being initialized."
                     "</div>"
                 ),
                 margin=0,
             )
         ]
-        self.status.object = (
-            f'Preparing preview for "{self.experiment.value}" using {selected_env}.'
-        )
-        self.prepare_btn.disabled = True
-        self.run_btn.disabled = True
+        self.status.object = f'Generating simulation preview for "{self.experiment.value}" using {selected_env}.'
+        self._set_run_controls_disabled(True)
         try:
             launcher, fallback_note = self._prepare_preview_launcher(
                 self.experiment.value,
@@ -2103,23 +2173,21 @@ class _SingleExperimentController:
                     margin=0,
                 )
             ]
-            self.status.object = f"Cannot prepare the single experiment preview: {exc}"
-            self.prepare_btn.disabled = False
-            self.run_btn.disabled = False
+            self.status.object = f"Cannot generate the simulation preview: {exc}"
+            self._set_run_controls_disabled(False)
             return
 
         self.preview_meta.object = self._preview_metadata_html(parameters, selected_env)
         self.preview[:] = [preview]
         status = (
-            f'Prepared preview for "{self.experiment.value}" using {selected_env}. '
+            f'Generated simulation preview for "{self.experiment.value}" using {selected_env}. '
             f"Reserved output directory for a future run: <code>{run_dir}</code>. "
             "The interactive preview is capped to the first 300 steps for responsiveness."
         )
         if fallback_note:
             status = f"{status} {fallback_note}"
         self.status.object = status
-        self.prepare_btn.disabled = False
-        self.run_btn.disabled = False
+        self._set_run_controls_disabled(False)
 
     def _on_run_experiment(self, *_: object) -> None:
         try:
@@ -2129,11 +2197,7 @@ class _SingleExperimentController:
             self.status.object = f"Cannot start the single experiment run: {exc}"
             return
 
-        selected_env = (
-            "template default"
-            if self.environment_select.value == "__template__"
-            else str(self.environment_select.value)
-        )
+        selected_env = self._selected_environment_label()
         self.status.object = (
             f'Running "{self.experiment.value}" using {selected_env}. '
             f"Outputs will be stored under <code>{run_dir}</code>. "
@@ -2201,6 +2265,7 @@ class _SingleExperimentController:
                 self.summary,
                 pn.Row(
                     self.prepare_btn,
+                    self.simulation_preview_btn,
                     self.run_btn,
                     sizing_mode="stretch_width",
                     margin=0,

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -951,14 +951,32 @@ class _SingleExperimentController:
             disabled=True,
         )
         self.video_fps = pn.widgets.IntInput(
-            name="Video fps",
-            value=30,
+            name="Video speed-up",
+            value=1,
             step=1,
             start=1,
             end=120,
             disabled=True,
+            description=(
+                "Controls video playback speed, not the encoder frame rate. "
+                "1x keeps the saved video close to simulated real time. 2x plays "
+                "twice as fast and makes the video about half as long; 5x plays "
+                "five times as fast and makes it about one fifth as long."
+            ),
         )
         self.show_display = pn.widgets.Checkbox(name="Show display", value=False)
+        self.display_every_n_steps = pn.widgets.IntInput(
+            name="Display every N steps",
+            value=1,
+            step=1,
+            start=1,
+            end=20,
+            disabled=True,
+            description=(
+                "Live display redraw cadence. 1 updates every simulation step; "
+                "higher values redraw less often to reduce display overhead."
+            ),
+        )
         self.prepare_btn.width = None
         self.prepare_btn.sizing_mode = "stretch_width"
         self.simulation_preview_btn.width = None
@@ -1055,11 +1073,13 @@ class _SingleExperimentController:
         self.environment_select.param.watch(self._on_parameter_override_change, "value")
         self.parameter_group.param.watch(self._on_parameter_group_change, "value")
         self.save_video.param.watch(self._on_save_video_change, "value")
+        self.show_display.param.watch(self._on_show_display_change, "value")
         self.refresh_environments_btn.on_click(self._on_refresh_environments)
         self.prepare_btn.on_click(self._on_prepare_preview)
         self.simulation_preview_btn.on_click(self._on_generate_simulation_preview)
         self.run_btn.on_click(self._on_run_experiment)
 
+        self._on_show_display_change()
         self._refresh_environment_options()
         self._refresh_summary()
         self._refresh_parameter_editor()
@@ -1983,6 +2003,9 @@ class _SingleExperimentController:
         self.video_filename.disabled = not enabled
         self.video_fps.disabled = not enabled
 
+    def _on_show_display_change(self, *_: object) -> None:
+        self.display_every_n_steps.disabled = not bool(self.show_display.value)
+
     def _on_parameter_override_change(self, *_: object) -> None:
         self._parameter_seed_overrides = util.AttrDict()
         self._refresh_parameter_editor()
@@ -2043,7 +2066,10 @@ class _SingleExperimentController:
     def _runtime_screen_kws(self, run_dir: Path) -> dict[str, Any]:
         kws: dict[str, Any] = {
             "show_display": bool(self.show_display.value),
+            "display_every_n_steps": int(self.display_every_n_steps.value),
         }
+        if self.show_display.value:
+            kws["vis_mode"] = "video"
         if self.save_video.value:
             video_name = _safe_slug(
                 (self.video_filename.value or "").strip() or run_dir.name
@@ -2064,6 +2090,9 @@ class _SingleExperimentController:
         self.simulation_preview_btn.disabled = disabled
         self.run_btn.disabled = disabled
         self.preview_frames_input.disabled = disabled
+        self.display_every_n_steps.disabled = disabled or not bool(
+            self.show_display.value
+        )
         self.refresh_environments_btn.disabled = disabled
 
     def _execute_run_experiment(
@@ -2378,6 +2407,7 @@ class _SingleExperimentController:
             self.video_filename,
             self.video_fps,
             self.show_display,
+            self.display_every_n_steps,
             css_classes=["lw-single-exp-media"],
             sizing_mode="stretch_width",
             margin=0,

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -926,7 +926,7 @@ class _SingleExperimentController:
             button_type="default",
         )
         self.prepare_btn = pn.widgets.Button(
-            name="Prepare configuration preview",
+            name="Arena Preview",
             button_type="primary",
         )
         self.simulation_preview_btn = pn.widgets.Button(
@@ -1033,7 +1033,7 @@ class _SingleExperimentController:
             "font-size": "12px",
             "line-height": "1.55",
             "color": "rgba(17, 17, 17, 0.76)",
-            "padding": "0 6px",
+            "padding": "0 6px 0 12px",
         }
         self.status = pn.pane.Markdown(
             "",
@@ -2298,7 +2298,7 @@ class _SingleExperimentController:
                 raise ValueError("No preview frames were generated.")
             state = env_params_to_canvas_state(
                 parameters.env_params,
-                larva_groups=parameters.get("larva_groups", {}),
+                larva_groups=None,
                 show_group_shapes=False,
             )
             canvas = EnvironmentCanvas(editable=False)
@@ -2418,11 +2418,11 @@ class _SingleExperimentController:
                 self.run_name,
                 self.environment_select,
                 self.refresh_environments_btn,
-                media_controls,
                 self.summary,
                 self.preview_action_row,
                 self.preview_options_row,
                 self.preview_generate_row,
+                media_controls,
                 self.execution_action_row,
                 self.status,
                 sizing_mode="stretch_width",

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -1143,7 +1143,9 @@ class _SingleExperimentController:
 
         # Explicit exact match first.
         parameters = reg.conf.Exp.getID(experiment_id)
-        env_params = parameters.get("env_params") if isinstance(parameters, dict) else None
+        env_params = (
+            parameters.get("env_params") if isinstance(parameters, dict) else None
+        )
         if isinstance(env_params, str) and env_params in env_conf_ids:
             return env_params
         if isinstance(env_params, dict):
@@ -2379,7 +2381,9 @@ class _SingleExperimentController:
             )
         ]
         experiment = self._selected_experiment()
-        self.status.object = f'Generating simulation preview for "{experiment}" using {selected_env}.'
+        self.status.object = (
+            f'Generating simulation preview for "{experiment}" using {selected_env}.'
+        )
         self._set_run_controls_disabled(True)
         launcher = None
         try:

--- a/src/larvaworld/portal/simulation/single_experiment_app.py
+++ b/src/larvaworld/portal/simulation/single_experiment_app.py
@@ -159,6 +159,7 @@ _ENRICHMENT_ANOT_KEY_OPTIONS = [
 _ODORSCAPE_OPTIONS = ["Analytical", "Gaussian", "Diffusion"]
 _PREVIEW_STEP_CAP = 300
 _REGISTRY_ENV_PRESET_PREFIX = "__registry__:"
+_WORKSPACE_ENV_PRESET_PREFIX = "__workspace__:"
 _NONE_OPTION_LABEL = "None"
 
 
@@ -170,6 +171,46 @@ def _safe_slug(value: str) -> str:
 def _default_run_name(experiment_id: str) -> str:
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     return f"{_safe_slug(experiment_id)}_{stamp}"
+
+
+def _default_experiment_template() -> str | None:
+    experiment_ids = list(reg.conf.Exp.confIDs)
+    if not experiment_ids:
+        return None
+    return "dish" if "dish" in experiment_ids else experiment_ids[0]
+
+
+class _SingleExperimentSelection(param.Parameterized):
+    experiment_template = reg.conf.Exp.confID_selector(
+        default=_default_experiment_template()
+    )
+    environment_preset = param.Selector(
+        default="__template__",
+        objects={"Template default environment": "__template__"},
+        doc=(
+            "Environment preset from the template default, workspace JSON presets, "
+            "or registry Env configurations."
+        ),
+    )
+
+    def __init__(
+        self,
+        *,
+        experiment_ids: list[str],
+        default_experiment: str,
+        environment_options: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(experiment_template=default_experiment)
+        self.param["experiment_template"].objects = experiment_ids
+        self.param["experiment_template"].label = "Experiment template"
+        self.param["environment_preset"].label = "Environment preset"
+        if environment_options is not None:
+            self.set_environment_options(environment_options)
+
+    def set_environment_options(self, options: dict[str, str]) -> None:
+        self.param["environment_preset"].objects = options
+        if self.environment_preset not in options.values():
+            self.environment_preset = "__template__"
 
 
 def _editor_group_title(key: str) -> str:
@@ -907,19 +948,19 @@ class _SingleExperimentController:
     def __init__(self) -> None:
         experiment_ids = list(reg.conf.Exp.confIDs)
         default_experiment = "dish" if "dish" in experiment_ids else experiment_ids[0]
-        self.experiment = pn.widgets.Select(
-            name="Experiment template",
-            value=default_experiment,
-            options=experiment_ids,
+        self.selection = _SingleExperimentSelection(
+            experiment_ids=experiment_ids,
+            default_experiment=default_experiment,
+        )
+        self.experiment = pn.widgets.Select.from_param(
+            self.selection.param.experiment_template
         )
         self.run_name = pn.widgets.TextInput(
             name="Run name",
-            value=_default_run_name(self.experiment.value),
+            value=_default_run_name(self.selection.experiment_template),
         )
-        self.environment_select = pn.widgets.Select(
-            name="Environment preset",
-            options={},
-            value="__template__",
+        self.environment_select = pn.widgets.Select.from_param(
+            self.selection.param.environment_preset
         )
         self.refresh_environments_btn = pn.widgets.Button(
             name="Refresh environment",
@@ -1068,9 +1109,11 @@ class _SingleExperimentController:
             sizing_mode="stretch_width",
         )
 
-        self.experiment.param.watch(self._on_experiment_change, "value")
+        self.selection.param.watch(self._on_experiment_change, "experiment_template")
         self.run_name.param.watch(self._on_run_name_change, "value")
-        self.environment_select.param.watch(self._on_parameter_override_change, "value")
+        self.selection.param.watch(
+            self._on_parameter_override_change, "environment_preset"
+        )
         self.parameter_group.param.watch(self._on_parameter_group_change, "value")
         self.save_video.param.watch(self._on_save_video_change, "value")
         self.show_display.param.watch(self._on_show_display_change, "value")
@@ -1091,26 +1134,72 @@ class _SingleExperimentController:
     def _experiment_dir(self) -> Path:
         return get_workspace_dir("experiments")
 
+    def _selected_experiment(self) -> str:
+        return str(self.selection.experiment_template)
+
+    def _template_default_env_id(self) -> str | None:
+        experiment_id = self._selected_experiment()
+        env_conf_ids = set(str(env_id) for env_id in reg.conf.Env.confIDs)
+
+        # Explicit exact match first.
+        parameters = reg.conf.Exp.getID(experiment_id)
+        env_params = parameters.get("env_params") if isinstance(parameters, dict) else None
+        if isinstance(env_params, str) and env_params in env_conf_ids:
+            return env_params
+        if isinstance(env_params, dict):
+            for key in (
+                "id",
+                "name",
+                "confID",
+                "config_id",
+                "configuration_id",
+                "env_id",
+                "default_env_id",
+            ):
+                value = env_params.get(key)
+                if isinstance(value, str) and value in env_conf_ids:
+                    return value
+
+        # Convention fallback for templates that share ID with Env presets.
+        if experiment_id in env_conf_ids:
+            return experiment_id
+
+        return None
+
     def _environment_options(self) -> dict[str, str]:
-        options = {"Template default environment": "__template__"}
+        template_default_env_id = self._template_default_env_id()
+        template_label = (
+            f"Template default: {template_default_env_id}"
+            if template_default_env_id is not None
+            else "Template default environment"
+        )
+        options = {template_label: "__template__"}
         preset_dir = self._environment_dir()
         preset_dir.mkdir(parents=True, exist_ok=True)
         workspace_labels: set[str] = set()
         for path in sorted(preset_dir.glob("*.json")):
             workspace_labels.add(path.stem)
             options[path.stem] = path.name
-        registry_options = {
-            f"Registry / {name}": f"{_REGISTRY_ENV_PRESET_PREFIX}{name}"
-            for name in sorted(str(key) for key in reg.conf.Env.dict.keys())
-            if name not in workspace_labels
-        }
+        registry_options = {}
+        for name in sorted(str(key) for key in reg.conf.Env.dict.keys()):
+            if name in workspace_labels:
+                continue
+            label = f"Registry / {name}"
+            if template_default_env_id is not None and name == template_default_env_id:
+                label += " [template default]"
+            registry_options[label] = f"{_REGISTRY_ENV_PRESET_PREFIX}{name}"
         options.update(registry_options)
         return options
 
     def _load_selected_environment(self) -> util.AttrDict | None:
-        selected = self.environment_select.value
+        selected = self.selection.environment_preset
         if selected in {None, "", "__template__"}:
             return None
+        if str(selected).startswith(_WORKSPACE_ENV_PRESET_PREFIX):
+            filename = str(selected)[len(_WORKSPACE_ENV_PRESET_PREFIX) :]
+            preset_path = self._environment_dir() / filename
+            payload = json.loads(preset_path.read_text(encoding="utf-8"))
+            return util.AttrDict(payload)
         if str(selected).startswith(_REGISTRY_ENV_PRESET_PREFIX):
             registry_id = str(selected)[len(_REGISTRY_ENV_PRESET_PREFIX) :]
             return util.AttrDict(reg.conf.Env.getID(registry_id)).get_copy()
@@ -1119,9 +1208,14 @@ class _SingleExperimentController:
         return util.AttrDict(payload)
 
     def _selected_environment_label(self) -> str:
-        selected = self.environment_select.value
+        selected = self.selection.environment_preset
         if selected == "__template__":
             return "template default"
+        if selected is not None and str(selected).startswith(
+            _WORKSPACE_ENV_PRESET_PREFIX
+        ):
+            filename = str(selected)[len(_WORKSPACE_ENV_PRESET_PREFIX) :]
+            return Path(filename).stem
         if selected is not None and str(selected).startswith(
             _REGISTRY_ENV_PRESET_PREFIX
         ):
@@ -1189,7 +1283,7 @@ class _SingleExperimentController:
         return merged
 
     def _build_parameters(self) -> util.AttrDict:
-        parameters = reg.conf.Exp.getID(self.experiment.value).get_copy()
+        parameters = reg.conf.Exp.getID(self._selected_experiment()).get_copy()
         parameters["duration"] = float(parameters.get("duration", 5.0))
         environment_payload = self._load_selected_environment()
         if environment_payload is not None:
@@ -1212,28 +1306,31 @@ class _SingleExperimentController:
         try:
             options = self._environment_options()
         except WorkspaceError as exc:
-            self.environment_select.options = {"Workspace unavailable": "__template__"}
-            self.environment_select.value = "__template__"
+            self.selection.set_environment_options(
+                {"Workspace unavailable": "__template__"}
+            )
+            self.selection.environment_preset = "__template__"
             self.environment_select.disabled = True
             self.refresh_environments_btn.disabled = True
             self.status.object = f"Cannot load workspace environment presets: {exc}"
             return
-        selected = self.environment_select.value
-        self.environment_select.options = options
+        selected = self.selection.environment_preset
+        self.selection.set_environment_options(options)
         self.environment_select.disabled = False
         self.refresh_environments_btn.disabled = False
-        self.environment_select.value = (
+        self.selection.environment_preset = (
             selected if selected in options.values() else "__template__"
         )
 
     def _refresh_summary(self) -> None:
-        parameters = reg.conf.Exp.getID(self.experiment.value).get_copy()
+        experiment = self._selected_experiment()
+        parameters = reg.conf.Exp.getID(experiment).get_copy()
         larva_groups = list(parameters.get("larva_groups", {}).keys())
         env = util.AttrDict(parameters.env_params)
         epochs = parameters.get("trials", {}).get("epochs", {})
         self.summary.object = (
             '<div class="lw-single-exp-summary">'
-            f"<strong>Template:</strong> <code>{self.experiment.value}</code><br>"
+            f"<strong>Template:</strong> <code>{experiment}</code><br>"
             f"<strong>Default duration:</strong> {float(parameters.get('duration', 0.0)):.2f} min<br>"
             f"<strong>Arena geometry:</strong> {env.arena.geometry}<br>"
             f"<strong>Larva groups:</strong> {', '.join(larva_groups) if larva_groups else 'None'}<br>"
@@ -1243,7 +1340,7 @@ class _SingleExperimentController:
         )
 
     def _editable_flat_parameters(self) -> util.AttrDict:
-        parameters = reg.conf.Exp.getID(self.experiment.value).get_copy()
+        parameters = reg.conf.Exp.getID(self._selected_experiment()).get_copy()
         environment_payload = self._load_selected_environment()
         if environment_payload is not None:
             env_params = util.AttrDict(parameters.env_params).get_copy()
@@ -1985,17 +2082,19 @@ class _SingleExperimentController:
         self._render_parameter_group()
 
     def _on_experiment_change(self, *_: object) -> None:
+        experiment = self._selected_experiment()
         self._parameter_seed_overrides = util.AttrDict()
-        self.run_name.value = _default_run_name(self.experiment.value)
+        self.run_name.value = _default_run_name(experiment)
+        self._refresh_environment_options()
         self._refresh_summary()
         self._refresh_parameter_editor()
-        self.status.object = f'Template "{self.experiment.value}" loaded.'
+        self.status.object = f'Template "{experiment}" loaded.'
 
     def _on_run_name_change(self, *_: object) -> None:
         current = (self.video_filename.value or "").strip()
         if not current or current == _safe_slug(current):
             self.video_filename.value = _safe_slug(
-                self.run_name.value or self.experiment.value
+                self.run_name.value or self._selected_experiment()
             )
 
     def _on_save_video_change(self, *_: object) -> None:
@@ -2019,7 +2118,7 @@ class _SingleExperimentController:
         self.status.object = "Refreshed workspace environment presets."
 
     def _build_run_directory(self) -> Path:
-        run_id = _safe_slug(self.run_name.value or self.experiment.value)
+        run_id = _safe_slug(self.run_name.value or self._selected_experiment())
         base_dir = self._experiment_dir()
         candidate = base_dir / run_id
         if not candidate.exists():
@@ -2055,7 +2154,7 @@ class _SingleExperimentController:
         run_dir.mkdir(parents=True, exist_ok=False)
         plan_path = run_dir / "resolved_experiment.json"
         payload = self._resolved_plan_payload(
-            experiment=self.experiment.value,
+            experiment=self._selected_experiment(),
             run_name=self.run_name.value or run_dir.name,
             selected_env=selected_env,
             parameters=parameters,
@@ -2111,7 +2210,7 @@ class _SingleExperimentController:
             )
             screen_kws = self._runtime_screen_kws(run_dir)
             launcher = sim.ExpRun(
-                experiment=self.experiment.value,
+                experiment=self._selected_experiment(),
                 parameters=parameters,
                 id=run_dir.name,
                 dir=str(run_dir),
@@ -2132,7 +2231,7 @@ class _SingleExperimentController:
 
         dataset_count = len(datasets or [])
         self.status.object = (
-            f'Completed run "{self.experiment.value}". '
+            f'Completed run "{self._selected_experiment()}". '
             f"Stored outputs in <code>{run_dir}</code>. "
             f"Saved resolved config to <code>{plan_path.name}</code>. "
             f"Datasets produced: {dataset_count}."
@@ -2253,7 +2352,7 @@ class _SingleExperimentController:
         self.preview_meta.object = self._preview_metadata_html(parameters, selected_env)
         self.preview[:] = [canvas.view()]
         self.status.object = (
-            f'Prepared configuration preview for "{self.experiment.value}" using '
+            f'Prepared configuration preview for "{self._selected_experiment()}" using '
             f"{selected_env}. Reserved output directory for a future run: "
             f"<code>{run_dir}</code>. No simulation has been run."
         )
@@ -2279,12 +2378,13 @@ class _SingleExperimentController:
                 margin=0,
             )
         ]
-        self.status.object = f'Generating simulation preview for "{self.experiment.value}" using {selected_env}.'
+        experiment = self._selected_experiment()
+        self.status.object = f'Generating simulation preview for "{experiment}" using {selected_env}.'
         self._set_run_controls_disabled(True)
         launcher = None
         try:
             launcher, fallback_note = self._prepare_preview_launcher(
-                self.experiment.value,
+                experiment,
                 parameters,
                 run_dir,
             )
@@ -2334,7 +2434,7 @@ class _SingleExperimentController:
         self.preview[:] = [preview]
         displayed_end = frames[-1].tick * float(launcher.dt)
         status = (
-            f'Generated simulation preview for "{self.experiment.value}" using {selected_env}. '
+            f'Generated simulation preview for "{experiment}" using {selected_env}. '
             f"Reserved output directory for a future run: <code>{run_dir}</code>. "
             f"Simulation preview ready: {len(frames)} frames generated. "
             f"Displayed range: 0.0-{displayed_end:.1f} s simulated time. "
@@ -2354,8 +2454,9 @@ class _SingleExperimentController:
             return
 
         selected_env = self._selected_environment_label()
+        experiment = self._selected_experiment()
         self.status.object = (
-            f'Running "{self.experiment.value}" using {selected_env}. '
+            f'Running "{experiment}" using {selected_env}. '
             f"Outputs will be stored under <code>{run_dir}</code>. "
             "The UI will be unresponsive until the simulation finishes."
         )
@@ -2363,7 +2464,7 @@ class _SingleExperimentController:
             pn.pane.HTML(
                 (
                     '<div class="lw-single-exp-preview-placeholder">'
-                    f'Running "{html.escape(self.experiment.value)}" and writing outputs to '
+                    f'Running "{html.escape(experiment)}" and writing outputs to '
                     f"<code>{html.escape(str(run_dir))}</code>. "
                     "This view will update again after the simulation finishes."
                     "</div>"

--- a/tests/unit/portal/test_conftype_actions.py
+++ b/tests/unit/portal/test_conftype_actions.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import panel as pn
+import pytest
+
+from larvaworld.lib import reg, util
+from larvaworld.lib.reg import config as reg_config
+from larvaworld.lib.reg.generators import EnvConf
+from larvaworld.portal.config_widgets.conftype_actions import (
+    ConftypeActionsController,
+    build_conftype_actions,
+)
+
+
+@pytest.fixture()
+def isolated_env_conf_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    original_conf_dir = reg_config.CONF_DIR
+    original_env_dict = reg.conf.Env.dict
+    tmp_conf_dir = tmp_path / "confDicts"
+    tmp_conf_dir.mkdir()
+    monkeypatch.setattr(reg_config, "CONF_DIR", str(tmp_conf_dir))
+    reg.conf.Env.reset(recreate=True)
+    try:
+        yield tmp_conf_dir
+    finally:
+        monkeypatch.setattr(reg_config, "CONF_DIR", original_conf_dir)
+        reg.conf.Env.dict = original_env_dict
+
+
+def test_conftype_actions_save_load_delete_and_reset(
+    isolated_env_conf_dir: Path,
+) -> None:
+    loaded: list[tuple[str, object]] = []
+    saved: list[tuple[str, object]] = []
+    deleted: list[str] = []
+    reset: list[str | None] = []
+    statuses: list[tuple[str, str]] = []
+    selected_id = ["portal_test_env_actions"]
+    save_id = ["portal_test_env_actions"]
+
+    def _build_payload(config_id: str):
+        env = EnvConf()
+        env.arena.geometry = "circular"
+        return env.nestedConf
+
+    controller = ConftypeActionsController(
+        EnvConf,
+        conftype="Env",
+        build_save_payload=_build_payload,
+        get_selected_id=lambda: selected_id[0],
+        get_save_id=lambda: save_id[0],
+        on_load=lambda config_id, config: loaded.append((config_id, config)),
+        on_save=lambda config_id, payload: saved.append((config_id, payload)),
+        on_delete=lambda config_id: deleted.append(config_id),
+        on_reset=lambda config_id: reset.append(config_id),
+        on_status=lambda message, *, tone="neutral": statuses.append((message, tone)),
+        confirm_reset=False,
+    )
+
+    assert controller.save_current() is True
+    assert "portal_test_env_actions" in reg.conf.Env.confIDs
+    assert saved[0][0] == "portal_test_env_actions"
+
+    assert controller.load_selected() is True
+    assert loaded[0][0] == "portal_test_env_actions"
+
+    assert controller.delete_selected() is True
+    assert deleted == ["portal_test_env_actions"]
+    assert "portal_test_env_actions" not in reg.conf.Env.confIDs
+
+    assert controller.reset_store() is True
+    assert reset == [selected_id[0]]
+    assert statuses[-1][1] == "success"
+
+
+def test_build_conftype_actions_returns_panel_view() -> None:
+    view = build_conftype_actions(
+        EnvConf,
+        conftype="Env",
+        build_save_payload=lambda _config_id: util.AttrDict(),
+        get_selected_id=lambda: None,
+    )
+
+    assert isinstance(view, pn.Column)

--- a/tests/unit/portal/test_enrichment_widget.py
+++ b/tests/unit/portal/test_enrichment_widget.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import panel as pn
+import pytest
+
+from larvaworld.lib.param.enrichment import EnrichConf
+from larvaworld.lib.reg.generators import ExpConf
+from larvaworld.portal.config_widgets import build_enrichment_widget
+from larvaworld.portal.config_widgets.conftype_widget import ConftypeWidgetController
+
+
+def _find_widget(
+    viewable: pn.viewable.Viewable,
+    name: str,
+    widget_type: type[pn.widgets.Widget]
+    | tuple[type[pn.widgets.Widget], ...] = pn.widgets.Widget,
+):
+    for widget in viewable.select(widget_type):
+        if getattr(widget, "name", None) == name:
+            return widget
+    raise AssertionError(f"Could not find widget {name!r}.")
+
+
+def test_enrichment_widget_uses_core_param_fields() -> None:
+    enrichment = EnrichConf()
+    widget = build_enrichment_widget(enrichment)
+
+    assert pn.Column(widget).get_root() is not None
+
+    proc_keys = _find_widget(widget, "Proc keys", pn.widgets.MultiChoice)
+    anot_keys = _find_widget(widget, "Anot keys", pn.widgets.MultiChoice)
+    tor_durs = _find_widget(widget, "Tor durs", pn.widgets.LiteralInput)
+    recompute = _find_widget(widget, "Recompute", pn.widgets.Checkbox)
+    mode = _find_widget(widget, "Mode", pn.widgets.Select)
+
+    proc_keys.value = ["spatial", "source"]
+    anot_keys.value = ["patch_residency"]
+    tor_durs.value = [8, 16]
+    recompute.value = True
+    mode.value = "full"
+
+    assert enrichment.proc_keys == ["spatial", "source"]
+    assert enrichment.anot_keys == ["patch_residency"]
+    assert enrichment.tor_durs == [8, 16]
+    assert enrichment.recompute is True
+    assert enrichment.mode == "full"
+
+
+def test_enrichment_widget_edits_preprocessing_config() -> None:
+    enrichment = EnrichConf()
+    widget = build_enrichment_widget(enrichment)
+
+    rescale_by = _find_widget(widget, "Rescale by", pn.widgets.LiteralInput)
+    filter_f = _find_widget(widget, "Filter f", pn.widgets.LiteralInput)
+    transposition = _find_widget(widget, "Transposition", pn.widgets.Select)
+    interpolate_nans = _find_widget(widget, "Interpolate nans", pn.widgets.Checkbox)
+
+    rescale_by.value = 0.002
+    filter_f.value = 1.5
+    transposition.value = "arena"
+    interpolate_nans.value = True
+
+    assert enrichment.pre_kws.rescale_by == pytest.approx(0.002)
+    assert enrichment.pre_kws.filter_f == pytest.approx(1.5)
+    assert enrichment.pre_kws.transposition == "arena"
+    assert enrichment.pre_kws.interpolate_nans is True
+
+
+def test_exp_conftype_widget_uses_typed_enrichment_helper() -> None:
+    controller = ConftypeWidgetController(ExpConf, conftype="Exp", allow_reset=False)
+
+    widgets = {
+        getattr(widget, "name", None)
+        for widget in controller.view.select(pn.widgets.Widget)
+        if getattr(widget, "name", None)
+    }
+
+    assert "Proc keys" in widgets
+    assert "Anot keys" in widgets
+    assert "Rescale by" in widgets

--- a/tests/unit/portal/test_environment_canvas.py
+++ b/tests/unit/portal/test_environment_canvas.py
@@ -127,7 +127,54 @@ def test_environment_canvas_draws_static_environment_sources() -> None:
     assert len(canvas.source_group_member_source.data["x"]) == 5
     assert canvas.border_source.data["id"] == ["wall"]
     assert canvas.larva_group_circle_source.data["id"] == ["larvae"]
-    assert len(canvas.larva_group_member_source.data["x"]) == 8
+    assert len(canvas.larva_group_member_source.data["x0"]) == 8
+
+
+def test_environment_canvas_source_group_circle_matches_builder_semantics() -> None:
+    canvas = EnvironmentCanvas()
+    state = EnvironmentCanvasState(
+        arena=CanvasArena("rectangular", (0.1, 0.06)),
+        objects=(
+            CanvasObject(
+                object_id="source-group",
+                object_type="source_group",
+                x=0.0,
+                y=0.0,
+                color="#4caf50",
+                distribution_mode="uniform",
+                distribution_shape="circle",
+                distribution_n=4,
+                distribution_scale_x=0.005,
+                distribution_scale_y=0.02,
+            ),
+        ),
+    )
+
+    canvas.set_state(state)
+
+    assert canvas.source_group_circle_source.data["id"] == ["source-group"]
+    assert canvas.source_group_circle_source.data["r"] == [0.02]
+    assert canvas.source_group_ellipse_source.data["id"] == []
+
+
+def test_environment_canvas_legend_order_matches_builder_with_larva_extension() -> None:
+    canvas = EnvironmentCanvas()
+    legend_labels = [
+        item.label.value
+        for item in canvas.fig.legend[0].items
+        if isinstance(getattr(item.label, "value", None), str)
+    ]
+
+    assert legend_labels == [
+        "Source units",
+        "Source groups",
+        "Borders",
+        "Larva groups",
+        "Odor aura",
+        "Odorscape",
+        "Windscape",
+        "Thermoscape",
+    ]
 
 
 def test_environment_canvas_source_group_members_are_deterministic() -> None:
@@ -227,7 +274,7 @@ def test_environment_canvas_larva_group_unequal_circle_scale_draws_ellipse() -> 
     assert canvas.larva_group_ellipse_source.data["id"] == ["navigator"]
     assert canvas.larva_group_ellipse_source.data["w"] == [0.01]
     assert canvas.larva_group_ellipse_source.data["h"] == [0.04]
-    assert len(canvas.larva_group_member_source.data["x"]) == 8
+    assert len(canvas.larva_group_member_source.data["x0"]) == 8
 
 
 def test_environment_canvas_named_colors_do_not_fallback_to_green() -> None:
@@ -262,6 +309,23 @@ def test_environment_canvas_named_colors_do_not_fallback_to_green() -> None:
     canvas.set_state(state)
 
     assert canvas.food_source.data["fill_color"] == ["#adadff"]
+    x0 = canvas.larva_group_member_source.data["x0"]
+    x1 = canvas.larva_group_member_source.data["x1"]
+    y0 = canvas.larva_group_member_source.data["y0"]
+    y1 = canvas.larva_group_member_source.data["y1"]
+    assert len(x0) == 5
+    assert len(x1) == 5
+    assert len(y0) == 5
+    assert len(y1) == 5
+    for i in range(5):
+        cx = 0.5 * (x0[i] + x1[i])
+        cy = 0.5 * (y0[i] + y1[i])
+        length = ((x1[i] - x0[i]) ** 2 + (y1[i] - y0[i]) ** 2) ** 0.5
+        assert cx == pytest.approx(-0.04)
+        assert cy == pytest.approx(0.0)
+        assert length == pytest.approx(0.0009)
+    assert "r" not in canvas.larva_group_member_source.data
+    assert "size" not in canvas.larva_group_member_source.data
     assert canvas.larva_group_member_source.data["fill_color"] == [
         "#2e2e2e",
         "#2e2e2e",

--- a/tests/unit/portal/test_environment_canvas.py
+++ b/tests/unit/portal/test_environment_canvas.py
@@ -177,6 +177,22 @@ def test_environment_canvas_legend_order_matches_builder_with_larva_extension() 
     ]
 
 
+def test_environment_canvas_source_groups_legend_targets_group_renderers() -> None:
+    canvas = EnvironmentCanvas()
+    source_group_item = next(
+        item
+        for item in canvas.fig.legend[0].items
+        if getattr(item.label, "value", None) == "Source groups"
+    )
+    data_sources = {renderer.data_source for renderer in source_group_item.renderers}
+
+    assert canvas.source_group_circle_source in data_sources
+    assert canvas.source_group_ellipse_source in data_sources
+    assert canvas.source_group_rect_source in data_sources
+    assert canvas.source_group_member_source in data_sources
+    assert canvas.food_highlight_source not in data_sources
+
+
 def test_environment_canvas_source_group_members_are_deterministic() -> None:
     canvas = EnvironmentCanvas()
     state = _state()

--- a/tests/unit/portal/test_environment_canvas.py
+++ b/tests/unit/portal/test_environment_canvas.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from larvaworld.portal.canvas_widgets.environment_canvas import EnvironmentCanvas
+from larvaworld.portal.canvas_widgets.environment_models import (
+    CanvasArena,
+    CanvasObject,
+    EnvironmentCanvasState,
+)
+
+
+def _state() -> EnvironmentCanvasState:
+    return EnvironmentCanvasState(
+        arena=CanvasArena("rectangular", (0.2, 0.1)),
+        food_grid={"color": "#44aa55", "grid_dims": (4, 2)},
+        odorscape={"odorscape": "Gaussian", "color": "#99aa33"},
+        windscape={"wind_speed": 20.0, "wind_direction": 0.0, "color": "#ff0000"},
+        thermoscape={
+            "spread": 0.05,
+            "thermo_sources": {"hot": (0.01, 0.02), "cold": (-0.02, -0.01)},
+            "thermo_source_dTemps": {"hot": 5.0, "cold": -3.0},
+        },
+        objects=(
+            CanvasObject(
+                object_id="patch",
+                object_type="source_unit",
+                x=0.01,
+                y=0.02,
+                radius=0.004,
+                color="#44aa55",
+                amount=1.0,
+                odor_id="apple",
+                odor_intensity=1.2,
+                odor_spread=0.015,
+            ),
+            CanvasObject(
+                object_id="group",
+                object_type="source_group",
+                x=-0.02,
+                y=0.01,
+                radius=0.003,
+                color="#6688aa",
+                amount=1.0,
+                odor_id="yeast",
+                odor_intensity=1.0,
+                odor_spread=0.01,
+                distribution_mode="uniform",
+                distribution_shape="oval",
+                distribution_n=5,
+                distribution_scale_x=0.02,
+                distribution_scale_y=0.01,
+            ),
+            CanvasObject(
+                object_id="wall",
+                object_type="border_segment",
+                x=-0.05,
+                y=-0.02,
+                x2=0.05,
+                y2=-0.02,
+                width=0.002,
+                color="#333333",
+            ),
+            CanvasObject(
+                object_id="larvae",
+                object_type="larva_group",
+                x=0.0,
+                y=-0.01,
+                color="#2f4858",
+                distribution_shape="circle",
+                distribution_scale_x=0.015,
+                distribution_scale_y=0.015,
+                distribution_n=8,
+            ),
+        ),
+    )
+
+
+def test_environment_canvas_view_is_stable_across_set_state() -> None:
+    canvas = EnvironmentCanvas()
+    view = canvas.view()
+
+    canvas.set_state(_state())
+    canvas.set_state(_state())
+
+    assert canvas.view() is view
+
+
+def test_environment_canvas_draws_rectangular_and_circular_arena() -> None:
+    canvas = EnvironmentCanvas()
+    canvas.set_state(
+        EnvironmentCanvasState(arena=CanvasArena("rectangular", (0.2, 0.1)))
+    )
+
+    assert canvas.arena_source.data["w"] == [0.2]
+    assert canvas._arena_rect_renderer.visible is True
+    assert canvas._arena_circle_renderer.visible is False
+
+    canvas.set_state(EnvironmentCanvasState(arena=CanvasArena("circular", (0.2, 0.2))))
+
+    assert canvas._arena_rect_renderer.visible is False
+    assert canvas._arena_circle_renderer.visible is True
+
+
+def test_environment_canvas_ranges_preserve_one_to_one_axis_ratio() -> None:
+    canvas = EnvironmentCanvas(width=760, height=620)
+    canvas.set_state(
+        EnvironmentCanvasState(arena=CanvasArena("rectangular", (0.1, 0.1)))
+    )
+
+    x_span = canvas.fig.x_range.end - canvas.fig.x_range.start
+    y_span = canvas.fig.y_range.end - canvas.fig.y_range.start
+
+    assert x_span / y_span == pytest.approx(760 / 620)
+
+
+def test_environment_canvas_draws_static_environment_sources() -> None:
+    canvas = EnvironmentCanvas()
+    canvas.set_state(_state())
+
+    assert len(canvas.food_grid_cell_source.data["x"]) == 8
+    assert canvas.food_source.data["id"] == ["patch"]
+    assert len(canvas.odor_layer_source.data["x"]) > 0
+    assert canvas.odor_peak_source.data["id"]
+    assert canvas.source_group_ellipse_source.data["id"] == ["group"]
+    assert len(canvas.source_group_member_source.data["x"]) == 5
+    assert canvas.border_source.data["id"] == ["wall"]
+    assert canvas.larva_group_circle_source.data["id"] == ["larvae"]
+    assert len(canvas.larva_group_member_source.data["x"]) == 8
+
+
+def test_environment_canvas_source_group_members_are_deterministic() -> None:
+    canvas = EnvironmentCanvas()
+    state = _state()
+    before = np.random.get_state()
+
+    canvas.set_state(state)
+    first = dict(canvas.source_group_member_source.data)
+    canvas.set_state(state)
+    second = dict(canvas.source_group_member_source.data)
+    after = np.random.get_state()
+
+    assert first == second
+    assert all(np.array_equal(a, b) for a, b in zip(before[1:], after[1:]))
+
+
+def test_environment_canvas_draws_scape_layers() -> None:
+    canvas = EnvironmentCanvas()
+    canvas.set_state(_state())
+
+    assert len(canvas.odorscape_contour_source.data["x"]) > 0
+    assert len(canvas.windscape_segment_source.data["x0"]) == 9
+    assert len(canvas.windscape_head_source.data["x"]) == 9
+    assert len(canvas.thermoscape_aura_source.data["x"]) == 6
+    assert canvas.thermoscape_marker_source.data["id"] == ["hot", "cold"]
+
+
+def test_environment_canvas_clear_and_highlight_are_stable() -> None:
+    canvas = EnvironmentCanvas()
+    canvas.set_state(_state())
+
+    canvas.set_selected_object("patch")
+    assert canvas.food_highlight_source.data["x"] == [0.01]
+
+    canvas.set_selected_object("missing")
+    assert canvas.food_highlight_source.data["x"] == []
+
+    view = canvas.view()
+    canvas.clear()
+
+    assert canvas.view() is view
+    assert canvas.food_source.data["id"] == []
+    assert canvas.source_group_member_source.data["x"] == []
+    assert canvas.border_source.data["id"] == []
+
+
+def test_environment_canvas_malformed_optional_scapes_do_not_block_base_render() -> (
+    None
+):
+    canvas = EnvironmentCanvas()
+    state = EnvironmentCanvasState(
+        arena=CanvasArena("rectangular", (0.2, 0.1)),
+        objects=(
+            CanvasObject(
+                object_id="patch",
+                object_type="source_unit",
+                x=0.01,
+                y=0.02,
+                radius=0.004,
+            ),
+        ),
+        odorscape={"grid_dims": object()},
+        windscape={"wind_speed": "not-a-number"},
+        thermoscape={"thermo_sources": {"bad": object()}},
+    )
+
+    canvas.set_state(state)
+
+    assert canvas.arena_source.data["w"] == [0.2]
+    assert canvas.food_source.data["id"] == ["patch"]
+
+
+def test_environment_canvas_larva_group_unequal_circle_scale_draws_ellipse() -> None:
+    canvas = EnvironmentCanvas()
+    state = EnvironmentCanvasState(
+        arena=CanvasArena("rectangular", (0.1, 0.06)),
+        objects=(
+            CanvasObject(
+                object_id="navigator",
+                object_type="larva_group",
+                x=-0.04,
+                y=0.0,
+                color="black",
+                distribution_mode="uniform",
+                distribution_shape="circle",
+                distribution_n=8,
+                distribution_scale_x=0.005,
+                distribution_scale_y=0.02,
+            ),
+        ),
+    )
+
+    canvas.set_state(state)
+
+    assert canvas.larva_group_circle_source.data["id"] == []
+    assert canvas.larva_group_ellipse_source.data["id"] == ["navigator"]
+    assert canvas.larva_group_ellipse_source.data["w"] == [0.01]
+    assert canvas.larva_group_ellipse_source.data["h"] == [0.04]
+    assert len(canvas.larva_group_member_source.data["x"]) == 8
+
+
+def test_environment_canvas_named_colors_do_not_fallback_to_green() -> None:
+    canvas = EnvironmentCanvas()
+    state = EnvironmentCanvasState(
+        arena=CanvasArena("rectangular", (0.1, 0.06)),
+        objects=(
+            CanvasObject(
+                object_id="target",
+                object_type="source_unit",
+                x=0.0,
+                y=0.0,
+                radius=0.003,
+                color="blue",
+                amount=0.0,
+            ),
+            CanvasObject(
+                object_id="navigator",
+                object_type="larva_group",
+                x=-0.04,
+                y=0.0,
+                color="black",
+                distribution_mode="uniform",
+                distribution_shape="circle",
+                distribution_n=5,
+                distribution_scale_x=0.0,
+                distribution_scale_y=0.0,
+            ),
+        ),
+    )
+
+    canvas.set_state(state)
+
+    assert canvas.food_source.data["fill_color"] == ["#adadff"]
+    assert canvas.larva_group_member_source.data["fill_color"] == [
+        "#2e2e2e",
+        "#2e2e2e",
+        "#2e2e2e",
+        "#2e2e2e",
+        "#2e2e2e",
+    ]

--- a/tests/unit/portal/test_environment_canvas.py
+++ b/tests/unit/portal/test_environment_canvas.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from larvaworld.portal.canvas_widgets.environment_canvas import EnvironmentCanvas
+from larvaworld.portal.canvas_widgets.environment_canvas import (
+    DEFAULT_LARVA_COLOR,
+    EnvironmentCanvas,
+)
 from larvaworld.portal.canvas_widgets.environment_models import (
     CanvasArena,
     CanvasObject,
     EnvironmentCanvasState,
+    LarvaPreviewFrame,
 )
 
 
@@ -74,6 +78,14 @@ def _state() -> EnvironmentCanvasState:
                 distribution_n=8,
             ),
         ),
+    )
+
+
+def _legend_item(canvas: EnvironmentCanvas, label: str):
+    return next(
+        item
+        for item in canvas.fig.legend[0].items
+        if getattr(item.label, "value", None) == label
     )
 
 
@@ -165,25 +177,21 @@ def test_environment_canvas_legend_order_matches_builder_with_larva_extension() 
         if isinstance(getattr(item.label, "value", None), str)
     ]
 
-    assert legend_labels == [
-        "Source units",
-        "Source groups",
-        "Borders",
-        "Larva groups",
-        "Odor aura",
-        "Odorscape",
-        "Windscape",
-        "Thermoscape",
-    ]
+    assert "Source units" in legend_labels
+    assert "Source groups" in legend_labels
+    assert "Borders" in legend_labels
+    assert "Larva groups" in legend_labels
+    assert "Simulated larvae" in legend_labels
+    assert "Larva trails" in legend_labels
+    assert "Odor aura" in legend_labels
+    assert "Odorscape" in legend_labels
+    assert "Windscape" in legend_labels
+    assert "Thermoscape" in legend_labels
 
 
 def test_environment_canvas_source_groups_legend_targets_group_renderers() -> None:
     canvas = EnvironmentCanvas()
-    source_group_item = next(
-        item
-        for item in canvas.fig.legend[0].items
-        if getattr(item.label, "value", None) == "Source groups"
-    )
+    source_group_item = _legend_item(canvas, "Source groups")
     data_sources = {renderer.data_source for renderer in source_group_item.renderers}
 
     assert canvas.source_group_circle_source in data_sources
@@ -191,6 +199,138 @@ def test_environment_canvas_source_groups_legend_targets_group_renderers() -> No
     assert canvas.source_group_rect_source in data_sources
     assert canvas.source_group_member_source in data_sources
     assert canvas.food_highlight_source not in data_sources
+
+
+def test_environment_canvas_set_larva_frame_populates_dynamic_sources() -> None:
+    canvas = EnvironmentCanvas()
+    canvas.set_larva_frame(
+        LarvaPreviewFrame(
+            tick=5,
+            centroids=((0.0, 0.0), (0.01, 0.02)),
+            heads=((0.001, 0.0),),
+            midlines=(((0.0, 0.0), (0.001, 0.0), (0.002, 0.0)),),
+            trails=(((0.0, 0.0), (0.0, 0.003)), ((0.01, 0.02), (0.011, 0.021))),
+            colors=("#111111",),
+        )
+    )
+
+    assert canvas.sim_larva_centroid_source.data["x"] == [0.0, 0.01]
+    assert canvas.sim_larva_centroid_source.data["color"] == [
+        "#111111",
+        DEFAULT_LARVA_COLOR,
+    ]
+    assert canvas.sim_larva_head_source.data["x"] == [0.001]
+    assert canvas.sim_larva_midline_source.data["xs"] == [[0.0, 0.001, 0.002]]
+    assert canvas.sim_larva_trail_source.data["ys"] == [[0.0, 0.003], [0.02, 0.021]]
+
+
+def test_environment_canvas_set_larva_frame_skips_invalid_optional_data() -> None:
+    canvas = EnvironmentCanvas()
+    canvas.set_larva_frame(
+        LarvaPreviewFrame(
+            tick=0,
+            centroids=((0.0, 0.0), ("bad", 1.0), (0.02, 0.03)),
+            heads=((0.001, None), (0.002, 0.003), ("bad", "bad")),
+            midlines=(
+                (),
+                ((0.0, 0.0),),
+                ((0.02, 0.03), (0.03, 0.03), ("x", 1.0)),
+            ),
+            trails=(
+                ((0.0, 0.0),),
+                ("bad",),
+                ((0.02, 0.03), (0.02, 0.04)),
+            ),
+            colors=("", "#ff0000"),
+        )
+    )
+
+    assert canvas.sim_larva_centroid_source.data["x"] == [0.0, 0.02]
+    assert canvas.sim_larva_centroid_source.data["color"] == [
+        DEFAULT_LARVA_COLOR,
+        DEFAULT_LARVA_COLOR,
+    ]
+    assert canvas.sim_larva_head_source.data["x"] == []
+    assert canvas.sim_larva_midline_source.data["xs"] == [[0.02, 0.03]]
+    assert canvas.sim_larva_trail_source.data["xs"] == [[0.02, 0.02]]
+
+
+def test_environment_canvas_clear_larva_frame_only_clears_dynamic_sources() -> None:
+    canvas = EnvironmentCanvas()
+    canvas.set_state(_state())
+    canvas.set_larva_frame(
+        LarvaPreviewFrame(
+            tick=1,
+            centroids=((0.0, 0.0),),
+            trails=(((0.0, 0.0), (0.0, 0.01)),),
+        )
+    )
+
+    assert canvas.larva_group_circle_source.data["id"] == ["larvae"]
+    assert canvas.sim_larva_centroid_source.data["x"] == [0.0]
+
+    canvas.clear_larva_frame()
+
+    assert canvas.sim_larva_centroid_source.data["x"] == []
+    assert canvas.sim_larva_head_source.data["x"] == []
+    assert canvas.sim_larva_midline_source.data["xs"] == []
+    assert canvas.sim_larva_trail_source.data["xs"] == []
+    assert canvas.larva_group_circle_source.data["id"] == ["larvae"]
+
+
+def test_environment_canvas_set_state_clears_stale_simulated_larvae() -> None:
+    canvas = EnvironmentCanvas()
+    canvas.set_larva_frame(
+        LarvaPreviewFrame(
+            tick=1,
+            centroids=((0.0, 0.0),),
+            heads=((0.0, 0.001),),
+            trails=(((0.0, 0.0), (0.0, 0.01)),),
+        )
+    )
+
+    assert canvas.sim_larva_centroid_source.data["x"] == [0.0]
+    canvas.set_state(_state())
+    assert canvas.sim_larva_centroid_source.data["x"] == []
+    assert canvas.sim_larva_head_source.data["x"] == []
+    assert canvas.sim_larva_trail_source.data["xs"] == []
+
+
+def test_environment_canvas_simulated_larvae_legend_membership() -> None:
+    canvas = EnvironmentCanvas()
+    simulated_item = _legend_item(canvas, "Simulated larvae")
+    trail_item = _legend_item(canvas, "Larva trails")
+    larva_groups_item = _legend_item(canvas, "Larva groups")
+
+    assert simulated_item.renderers == [
+        canvas._sim_larva_centroid_renderer,
+        canvas._sim_larva_head_renderer,
+        canvas._sim_larva_midline_renderer,
+    ]
+    assert trail_item.renderers == [canvas._sim_larva_trail_renderer]
+    assert canvas._sim_larva_centroid_renderer not in larva_groups_item.renderers
+    assert canvas._sim_larva_head_renderer not in larva_groups_item.renderers
+    assert canvas._sim_larva_midline_renderer not in larva_groups_item.renderers
+    assert canvas._sim_larva_trail_renderer not in larva_groups_item.renderers
+
+
+def test_environment_canvas_view_is_stable_across_larva_frame_updates() -> None:
+    canvas = EnvironmentCanvas()
+    view = canvas.view()
+
+    canvas.set_larva_frame(
+        LarvaPreviewFrame(tick=0, centroids=((0.0, 0.0),), colors=("#111111",))
+    )
+    canvas.set_larva_frame(
+        LarvaPreviewFrame(
+            tick=1,
+            centroids=((0.01, 0.01),),
+            heads=((0.011, 0.012),),
+            trails=(((0.0, 0.0), (0.01, 0.01)),),
+        )
+    )
+
+    assert canvas.view() is view
 
 
 def test_environment_canvas_source_group_members_are_deterministic() -> None:

--- a/tests/unit/portal/test_environment_mapping.py
+++ b/tests/unit/portal/test_environment_mapping.py
@@ -100,6 +100,48 @@ def test_env_params_to_canvas_state_maps_static_environment_layers() -> None:
     assert objects["explorer"].distribution_n == 6
 
 
+def test_env_params_to_canvas_state_can_hide_group_shapes() -> None:
+    env_params = {
+        "arena": {"geometry": "rectangular", "dims": [0.2, 0.1]},
+        "food_params": {
+            "source_units": {},
+            "source_groups": {
+                "cluster": {
+                    "distribution": {
+                        "N": 4,
+                        "loc": [0.0, 0.01],
+                        "mode": "uniform",
+                        "shape": "circle",
+                        "scale": [0.02, 0.01],
+                    }
+                }
+            },
+        },
+    }
+    larva_groups = {
+        "explorer": util.AttrDict(
+            {
+                "distribution": {
+                    "N": 6,
+                    "loc": [0.0, -0.02],
+                    "shape": "circle",
+                    "scale": [0.01, 0.01],
+                },
+            }
+        )
+    }
+
+    state = env_params_to_canvas_state(
+        env_params,
+        larva_groups=larva_groups,
+        show_group_shapes=False,
+    )
+    objects = {obj.object_id: obj for obj in state.objects}
+
+    assert objects["cluster"].distribution_show_shape is False
+    assert objects["explorer"].distribution_show_shape is False
+
+
 def test_env_params_to_canvas_state_skips_malformed_optional_sections() -> None:
     env_params = {
         "arena": {"geometry": "rectangular", "dims": [0.2, 0.1]},

--- a/tests/unit/portal/test_environment_mapping.py
+++ b/tests/unit/portal/test_environment_mapping.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import pytest
+
+from larvaworld.lib import util
+from larvaworld.portal.canvas_widgets.environment_mapping import (
+    env_params_to_canvas_state,
+)
+
+
+def test_env_params_to_canvas_state_maps_static_environment_layers() -> None:
+    env_params = util.AttrDict(
+        {
+            "arena": {"geometry": "circular", "dims": [0.24, 0.24], "torus": True},
+            "food_params": {
+                "source_units": {
+                    "patch": {
+                        "pos": [0.02, -0.01],
+                        "radius": 0.005,
+                        "amount": 2.0,
+                        "color": "#44aa55",
+                        "odor": {
+                            "id": "apple",
+                            "intensity": 1.0,
+                            "spread": 0.03,
+                        },
+                    }
+                },
+                "source_groups": {
+                    "cluster": {
+                        "radius": 0.003,
+                        "amount": 1.0,
+                        "color": "#6688aa",
+                        "distribution": {
+                            "N": 4,
+                            "loc": [0.0, 0.01],
+                            "mode": "uniform",
+                            "shape": "rect",
+                            "scale": [0.02, 0.01],
+                        },
+                        "odor": {
+                            "id": "yeast",
+                            "intensity": 0.8,
+                            "spread": 0.02,
+                        },
+                    }
+                },
+                "food_grid": {"color": "#77aa44", "grid_dims": [3, 2]},
+            },
+            "border_list": {
+                "wall": {
+                    "vertices": [[-0.02, 0.0], [0.02, 0.0]],
+                    "width": 0.002,
+                    "color": "#333333",
+                }
+            },
+            "odorscape": {"odorscape": "Gaussian", "color": "#99aa33"},
+            "windscape": {"wind_speed": 10.0, "wind_direction": 1.0},
+            "thermoscape": {
+                "spread": 0.04,
+                "thermo_sources": {"hot": (0.01, 0.02)},
+                "thermo_source_dTemps": {"hot": 3.0},
+            },
+        }
+    )
+    larva_groups = {
+        "explorer": util.AttrDict(
+            {
+                "distribution": {
+                    "N": 6,
+                    "loc": [0.0, -0.02],
+                    "shape": "circle",
+                    "scale": [0.01, 0.01],
+                },
+                "color": "#2f4858",
+            }
+        )
+    }
+
+    state = env_params_to_canvas_state(env_params, larva_groups=larva_groups)
+
+    assert state.arena.geometry == "circular"
+    assert state.arena.dims == (0.24, 0.24)
+    assert state.arena.torus is True
+    assert state.food_grid == {"color": "#77aa44", "grid_dims": [3, 2]}
+    assert state.odorscape == {"odorscape": "Gaussian", "color": "#99aa33"}
+    assert state.windscape["wind_speed"] == pytest.approx(10.0)
+    assert state.thermoscape["thermo_sources"]["hot"] == (0.01, 0.02)
+
+    objects = {obj.object_id: obj for obj in state.objects}
+    assert objects["patch"].object_type == "source_unit"
+    assert objects["patch"].x == pytest.approx(0.02)
+    assert objects["patch"].odor_id == "apple"
+    assert objects["cluster"].object_type == "source_group"
+    assert objects["cluster"].distribution_n == 4
+    assert objects["cluster"].distribution_shape == "rect"
+    assert objects["wall"].object_type == "border_segment"
+    assert objects["wall"].x2 == pytest.approx(0.02)
+    assert objects["explorer"].object_type == "larva_group"
+    assert objects["explorer"].distribution_n == 6
+
+
+def test_env_params_to_canvas_state_skips_malformed_optional_sections() -> None:
+    env_params = {
+        "arena": {"geometry": "rectangular", "dims": [0.2, 0.1]},
+        "food_params": {
+            "source_units": {
+                "patch": {"pos": [0.01, 0.02], "radius": 0.004},
+                "bad_patch": {"pos": ["bad"]},
+            },
+            "source_groups": {"bad_group": {"distribution": {"loc": ["bad"]}}},
+            "food_grid": "not-a-grid",
+        },
+        "border_list": {"bad_wall": {"vertices": [[0.0, 0.0]]}},
+        "odorscape": "not-a-scape",
+    }
+
+    state = env_params_to_canvas_state(env_params)
+
+    assert state.food_grid is None
+    assert state.odorscape is None
+    assert [obj.object_id for obj in state.objects] == ["patch"]
+
+
+def test_env_params_to_canvas_state_maps_all_flattened_border_pairs() -> None:
+    env_params = {
+        "arena": {"geometry": "rectangular", "dims": [0.2, 0.1]},
+        "food_params": {"source_units": {}, "source_groups": {}, "food_grid": {}},
+        "border_list": {
+            "obstacle": {
+                "vertices": [
+                    [0.0, 0.0],
+                    [0.01, 0.0],
+                    [0.01, 0.0],
+                    [0.01, 0.01],
+                    [0.01, 0.01],
+                    [0.0, 0.0],
+                ],
+                "width": 0.002,
+            }
+        },
+    }
+
+    state = env_params_to_canvas_state(env_params)
+    borders = [obj for obj in state.objects if obj.object_type == "border_segment"]
+
+    assert [obj.object_id for obj in borders] == [
+        "obstacle:0",
+        "obstacle:1",
+        "obstacle:2",
+    ]
+    assert borders[0].x == pytest.approx(0.0)
+    assert borders[1].y2 == pytest.approx(0.01)

--- a/tests/unit/portal/test_import_datasets_app.py
+++ b/tests/unit/portal/test_import_datasets_app.py
@@ -94,12 +94,17 @@ def test_import_datasets_controller_requires_active_workspace() -> None:
 
     assert controller.discover_button.disabled is True
     assert controller.import_button.disabled is True
+    assert controller.merged_checkbox.disabled is True
     assert "Configure an active workspace" in controller.status.object
 
 
 def test_import_datasets_lab_config_panel_loads_selected_configuration() -> None:
     controller = import_datasets_app._ImportDatasetsController()
 
+    assert isinstance(
+        controller.lab_actions,
+        import_datasets_app.ConftypeActionsController,
+    )
     assert controller.lab_config_name_input.value == controller.lab_select.value
     assert len(controller.lab_editor_sections.objects) == 3
     assert "Loaded LabFormat" in controller.lab_status.object
@@ -255,6 +260,45 @@ def test_import_datasets_tracker_framerate_panel_is_separate() -> None:
     ]
 
 
+def test_import_datasets_merged_checkbox_disables_candidate_dropdown_and_sets_request_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = initialize_workspace(tmp_path / "workspace")
+    set_active_workspace_path(workspace.root)
+
+    controller = import_datasets_app._ImportDatasetsController()
+    controller.raw_root_input.value = str(tmp_path / "raw")
+
+    candidate = RawDatasetCandidate(
+        candidate_id="dish01",
+        parent_dir="exploration",
+        display_name="exploration / dish01",
+        source_path=tmp_path / "raw" / "exploration" / "dish01",
+        warnings=[],
+    )
+    candidate_key = controller._candidate_option_key(candidate)
+    controller._candidate_by_key = {candidate_key: candidate}
+    controller.candidate_select.options = {
+        "Select a candidate": "",
+        candidate.display_name: candidate_key,
+    }
+    controller.candidate_select.value = candidate_key
+    controller.merged_checkbox.value = True
+    controller._sync_controls()
+
+    monkeypatch.setattr(
+        import_datasets_app,
+        "_candidate_import_overrides",
+        lambda _lab_id, _raw_root, _candidate: {},
+    )
+
+    request = controller._build_import_request()
+
+    assert controller.candidate_select.disabled is True
+    assert request.merged is True
+
+
 def test_import_datasets_lab_config_save_and_delete_use_registry_contract(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -274,8 +318,9 @@ def test_import_datasets_lab_config_save_and_delete_use_registry_contract(
         "delete",
         lambda config_id: deleted.append(config_id),
     )
-    monkeypatch.setattr(controller, "_refresh_lab_options", lambda **kwargs: None)
-    monkeypatch.setattr(controller, "_load_working_lab", lambda _lab_id: None)
+    monkeypatch.setattr(controller.lab_actions, "refresh_registry", lambda: None)
+    controller.lab_actions.on_save = None
+    controller.lab_actions.on_delete = None
 
     controller.lab_config_name_input.value = "LabCopy"
     controller._handle_lab_save()
@@ -306,18 +351,16 @@ def test_import_datasets_lab_config_reset_recreates_registry(
         lambda **kwargs: reset_calls.append(kwargs),
     )
     monkeypatch.setattr(
-        controller,
-        "_refresh_lab_options",
-        lambda **kwargs: refreshed.append(kwargs),
+        controller.lab_actions,
+        "refresh_registry",
+        lambda: refreshed.append({}),
     )
-    monkeypatch.setattr(
-        controller, "_load_working_lab", lambda lab_id: loaded.append(lab_id)
-    )
+    controller.lab_actions.on_reset = lambda lab_id: loaded.append(lab_id)
 
     controller._handle_lab_reset()
 
     assert reset_calls == [{"recreate": True}]
-    assert refreshed == [{"select_id": selected_lab_id}]
+    assert refreshed == [{}]
     assert loaded == [selected_lab_id]
     assert "registry recreated" in controller.lab_status.object
 

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -13,10 +13,12 @@ from larvaworld.lib.reg.larvagroup import LarvaGroup
 from larvaworld.portal.canvas_widgets.environment_models import (
     CanvasArena,
     EnvironmentCanvasState,
+    LarvaPreviewFrame,
 )
 from larvaworld.portal.landing_registry import ITEMS
 from larvaworld.portal.simulation.single_experiment_app import (
     _ExperimentPreview,
+    _FrameSimulationPreview,
     _SingleExperimentController,
     _builder_obstacle_border_vertices,
     _default_run_name,
@@ -217,6 +219,41 @@ def test_single_experiment_configuration_preview_uses_mapped_canvas_state(
     assert captured["larva_groups"] is not None
     assert captured["show_group_shapes"] is False
     assert controller.preview[0] is canvas_view
+
+
+def test_single_experiment_prepare_preview_uses_resolved_parameters_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    controller = _SingleExperimentController()
+    resolved = controller._build_parameters()
+
+    def fail_build_parameters():
+        raise AssertionError("_build_parameters should not be called directly")
+
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            pass
+
+        def set_state(self, state):
+            self.state = state
+
+        def view(self):
+            return pn.pane.HTML("canvas-view")
+
+    monkeypatch.setattr(controller, "_build_parameters", fail_build_parameters)
+    monkeypatch.setattr(controller, "_resolve_experiment_parameters", lambda: resolved)
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+
+    controller._on_prepare_preview()
+    assert isinstance(controller.preview[0], pn.pane.HTML)
 
 
 def test_single_experiment_configuration_preview_uses_environment_preset_override(
@@ -755,6 +792,41 @@ def test_single_experiment_run_experiment_explicitly_closes_screen_manager(
     assert "Completed run" in controller.status.object
 
 
+def test_single_experiment_run_experiment_uses_resolved_parameters_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    controller = _SingleExperimentController()
+    resolved = controller._build_parameters()
+    captured: dict[str, object] = {}
+
+    def fail_build_parameters():
+        raise AssertionError("_build_parameters should not be called directly")
+
+    def fake_execute(self, *, parameters, run_dir, selected_env):
+        captured["parameters"] = parameters
+        captured["run_dir"] = run_dir
+        captured["selected_env"] = selected_env
+
+    monkeypatch.setattr(controller, "_build_parameters", fail_build_parameters)
+    monkeypatch.setattr(controller, "_resolve_experiment_parameters", lambda: resolved)
+    monkeypatch.setattr(
+        _SingleExperimentController,
+        "_execute_run_experiment",
+        fake_execute,
+    )
+
+    controller.run_name.value = "dish_boundary"
+    controller._on_run_experiment()
+
+    assert captured["parameters"] is resolved
+    assert str(captured["run_dir"]).endswith("dish_boundary")
+
+
 def test_single_experiment_preview_status_uses_reserved_run_directory_wording(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -764,23 +836,47 @@ def test_single_experiment_preview_status_uses_reserved_run_directory_wording(
     set_active_workspace_path(workspace_root)
 
     class DummyPreviewLauncher:
-        def sim_setup(self, steps):
-            return None
+        def __init__(self):
+            self.p = util.AttrDict({"steps": 9})
+            self.dt = 0.1
 
-    class DummyPreview:
-        def __init__(self, launcher, launcher_ready=False):
-            self.launcher = launcher
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            self.editable = editable
+            self.state = None
+            self.frames: list[LarvaPreviewFrame] = []
+
+        def set_state(self, state):
+            self.state = state
+
+        def set_larva_frame(self, frame):
+            self.frames.append(frame)
 
         def view(self):
-            return "preview"
+            return pn.pane.HTML("canvas")
+
+    frame0 = LarvaPreviewFrame(tick=0, centroids=((0.0, 0.0),))
+    frame1 = LarvaPreviewFrame(tick=1, centroids=((0.01, 0.01),))
 
     monkeypatch.setattr(
         "larvaworld.portal.simulation.single_experiment_app._SingleExperimentController._prepare_preview_launcher",
         lambda self, experiment, parameters, run_dir: (DummyPreviewLauncher(), None),
     )
     monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.generate_preview_frames",
+        lambda launcher, preview_steps, **kwargs: [frame0, frame1],
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+    monkeypatch.setattr(
         "larvaworld.portal.simulation.single_experiment_app._ExperimentPreview",
-        DummyPreview,
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError(
+                "_ExperimentPreview should not be used in default preview path"
+            )
+        ),
     )
 
     controller = _SingleExperimentController()
@@ -788,6 +884,149 @@ def test_single_experiment_preview_status_uses_reserved_run_directory_wording(
     controller._on_generate_simulation_preview()
 
     assert "Reserved output directory for a future run" in controller.status.object
+    assert "Simulation preview ready: 2 frames generated." in controller.status.object
+    assert "Displayed range: 0.0-0.1 s simulated time." in controller.status.object
+    assert "Outputs are not stored" in controller.status.object
+
+
+def test_single_experiment_generate_preview_uses_resolved_parameters_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    controller = _SingleExperimentController()
+    resolved = controller._build_parameters()
+
+    def fail_build_parameters():
+        raise AssertionError("_build_parameters should not be called directly")
+
+    class DummyPreviewLauncher:
+        def __init__(self):
+            self.p = util.AttrDict({"steps": 3})
+            self.dt = 0.1
+
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            pass
+
+        def set_state(self, state):
+            self.state = state
+
+        def set_larva_frame(self, frame):
+            self.frame = frame
+
+        def view(self):
+            return pn.pane.HTML("canvas")
+
+    monkeypatch.setattr(controller, "_build_parameters", fail_build_parameters)
+    monkeypatch.setattr(controller, "_resolve_experiment_parameters", lambda: resolved)
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app._SingleExperimentController._prepare_preview_launcher",
+        lambda self, experiment, parameters, run_dir: (DummyPreviewLauncher(), None),
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.generate_preview_frames",
+        lambda launcher, preview_steps, **kwargs: [
+            LarvaPreviewFrame(tick=0, centroids=((0.0, 0.0),))
+        ],
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+
+    controller._on_generate_simulation_preview()
+
+
+def test_frame_simulation_preview_slider_is_random_access() -> None:
+    class DummyCanvas:
+        def __init__(self):
+            self.applied_ticks: list[int] = []
+
+        def set_larva_frame(self, frame: LarvaPreviewFrame) -> None:
+            self.applied_ticks.append(frame.tick)
+
+        def view(self):
+            return pn.pane.HTML("canvas")
+
+    canvas = DummyCanvas()
+    preview = _FrameSimulationPreview(
+        canvas=canvas,
+        frames=[
+            LarvaPreviewFrame(tick=0, centroids=((0.0, 0.0),)),
+            LarvaPreviewFrame(tick=1, centroids=((0.01, 0.01),)),
+            LarvaPreviewFrame(tick=2, centroids=((0.02, 0.02),)),
+        ],
+        dt=0.1,
+    )
+
+    assert canvas.applied_ticks == [0]
+    preview.frame_slider.value = 2
+    preview.frame_slider.value = 1
+
+    assert canvas.applied_ticks == [0, 2, 1]
+    assert "Frame:</strong> 1/2" in preview.metadata.object
+    assert "Tick:</strong> 1" in preview.metadata.object
+
+
+def test_generate_preview_uses_show_group_shapes_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    captured: dict[str, object] = {}
+
+    class DummyPreviewLauncher:
+        def __init__(self):
+            self.p = util.AttrDict({"steps": 1})
+            self.dt = 0.1
+
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            pass
+
+        def set_state(self, state):
+            captured["state"] = state
+
+        def set_larva_frame(self, frame):
+            captured["frame"] = frame
+
+        def view(self):
+            return pn.pane.HTML("canvas")
+
+    def fake_mapping(env_params, *, larva_groups=None, show_group_shapes=True):
+        captured["show_group_shapes"] = show_group_shapes
+        return EnvironmentCanvasState(arena=CanvasArena("rectangular", (0.1, 0.1)))
+
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app._SingleExperimentController._prepare_preview_launcher",
+        lambda self, experiment, parameters, run_dir: (DummyPreviewLauncher(), None),
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.generate_preview_frames",
+        lambda launcher, preview_steps, **kwargs: [
+            LarvaPreviewFrame(tick=0, centroids=((0.0, 0.0),))
+        ],
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.env_params_to_canvas_state",
+        fake_mapping,
+    )
+
+    controller = _SingleExperimentController()
+    controller._on_generate_simulation_preview()
+
+    assert captured["show_group_shapes"] is False
 
 
 def test_single_experiment_preview_launcher_falls_back_when_overlap_elimination_breaks(

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -194,9 +194,10 @@ def test_single_experiment_configuration_preview_uses_mapped_canvas_state(
         def view(self):
             return canvas_view
 
-    def fake_mapping(env_params, *, larva_groups=None):
+    def fake_mapping(env_params, *, larva_groups=None, show_group_shapes=True):
         captured["env_params"] = env_params
         captured["larva_groups"] = larva_groups
+        captured["show_group_shapes"] = show_group_shapes
         return mapped_state
 
     monkeypatch.setattr(
@@ -214,6 +215,7 @@ def test_single_experiment_configuration_preview_uses_mapped_canvas_state(
     assert captured["state"] is mapped_state
     assert captured["env_params"] is not None
     assert captured["larva_groups"] is not None
+    assert captured["show_group_shapes"] is False
     assert controller.preview[0] is canvas_view
 
 

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import holoviews as hv
 import numpy as np
 import pytest
 
 from larvaworld.lib import util
 from larvaworld.lib.reg.larvagroup import LarvaGroup
 from larvaworld.portal.landing_registry import ITEMS
-from larvaworld.portal.single_experiment_app import (
+from larvaworld.portal.simulation.single_experiment_app import (
     _ExperimentPreview,
     _SingleExperimentController,
     _builder_obstacle_border_vertices,
@@ -27,6 +28,8 @@ from larvaworld.portal.workspace import (
 SINGLE_EXPERIMENT_APP_INCOMPLETE_REASON = (
     "single_experiment_app is incomplete; re-enable after app stabilization"
 )
+
+hv.extension("bokeh")
 
 
 @pytest.fixture(autouse=True)
@@ -141,14 +144,77 @@ def test_single_experiment_builder_obstacles_are_translated_into_border_entries(
     assert isinstance(border_list["Obstacle_obstacle_1"]["vertices"][0], tuple)
 
 
-@pytest.mark.skip(reason=SINGLE_EXPERIMENT_APP_INCOMPLETE_REASON)
+class _DummyPreviewAgents(list):
+    head = type("Head", (), {"front_end": []})()
+
+    def get_position(self):
+        return []
+
+
+class _DummyPreviewLauncher:
+    def __init__(
+        self,
+        *,
+        agents: _DummyPreviewAgents | None = None,
+        sources: list[object] | None = None,
+        borders: list[object] | None = None,
+        t: int = 0,
+        nsteps: int = 8,
+        step_hook=None,
+    ) -> None:
+        self.p = util.AttrDict(
+            {
+                "steps": nsteps,
+                "env_params": util.AttrDict(
+                    {
+                        "arena": util.AttrDict(
+                            {"geometry": "circular", "dims": (0.2, 0.2)}
+                        )
+                    }
+                ),
+            }
+        )
+        self.dt = 0.1
+        self.Nsteps = nsteps
+        self.t = t
+        self.agents = agents if agents is not None else _DummyPreviewAgents()
+        self.sources = sources if sources is not None else []
+        self.borders = borders if borders is not None else []
+        self.step_calls = 0
+        self._step_hook = step_hook
+
+    def sim_step(self) -> None:
+        self.step_calls += 1
+        if self._step_hook is not None:
+            self._step_hook()
+            return
+        self.t += 1
+
+
+class _ProgressRecorder:
+    def __init__(self) -> None:
+        self.updates: list[int] = []
+
+    @property
+    def value(self) -> int:
+        if not self.updates:
+            return 0
+        return self.updates[-1]
+
+    @value.setter
+    def value(self, value: int) -> None:
+        self.updates.append(value)
+
+
+def _disable_dynamic_preview_layers(preview: _ExperimentPreview) -> None:
+    preview.draw_ops.draw_centroid = False
+    preview.draw_ops.draw_head = False
+    preview.draw_ops.draw_midline = False
+    preview.draw_ops.visible_trails = False
+    preview.draw_ops.draw_segs = False
+
+
 def test_single_experiment_preview_overlay_draws_sources_odors_and_borders() -> None:
-    class DummyAgents(list):
-        head = type("Head", (), {"front_end": []})()
-
-        def get_position(self):
-            return []
-
     source = util.AttrDict(
         {
             "pos": (0.02, 0.01),
@@ -164,39 +230,119 @@ def test_single_experiment_preview_overlay_draws_sources_odors_and_borders() -> 
             "border_xy": [np.array([[0.0, 0.0], [0.04, 0.0]])],
         }
     )
-    launcher = util.AttrDict(
-        {
-            "p": util.AttrDict(
-                {
-                    "steps": 8,
-                    "env_params": util.AttrDict(
-                        {
-                            "arena": util.AttrDict(
-                                {"geometry": "circular", "dims": (0.2, 0.2)}
-                            )
-                        }
-                    ),
-                }
-            ),
-            "dt": 0.1,
-            "Nsteps": 8,
-            "t": 0,
-            "agents": DummyAgents(),
-            "sources": [source],
-            "borders": [border],
-        }
-    )
+    launcher = _DummyPreviewLauncher(sources=[source], borders=[border])
 
     preview = _ExperimentPreview(launcher, launcher_ready=True)
-    preview.draw_ops.draw_centroid = False
-    preview.draw_ops.draw_head = False
-    preview.draw_ops.draw_midline = False
-    preview.draw_ops.visible_trails = False
-    preview.draw_ops.draw_segs = False
+    _disable_dynamic_preview_layers(preview)
 
     overlay = preview._draw_overlay()
 
     assert len(overlay) == 4
+
+
+def test_single_experiment_preview_disabled_layers_skip_expensive_agent_attrs() -> None:
+    class ExplodingAgent:
+        color = "#111111"
+
+        @property
+        def segs(self):
+            raise AssertionError("segs should not be accessed")
+
+        @property
+        def midline_xy(self):
+            raise AssertionError("midline_xy should not be accessed")
+
+        @property
+        def trajectory(self):
+            raise AssertionError("trajectory should not be accessed")
+
+    launcher = _DummyPreviewLauncher(agents=_DummyPreviewAgents([ExplodingAgent()]))
+    preview = _ExperimentPreview(launcher, launcher_ready=True)
+    _disable_dynamic_preview_layers(preview)
+
+    preview._draw_overlay()
+
+
+def test_single_experiment_preview_static_layers_are_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"source": 0, "odor": 0, "border": 0}
+
+    def source_layers(self):
+        calls["source"] += 1
+        return []
+
+    def odor_layers(self):
+        calls["odor"] += 1
+        return []
+
+    def border_layers(self):
+        calls["border"] += 1
+        return []
+
+    monkeypatch.setattr(_ExperimentPreview, "_source_layers", source_layers)
+    monkeypatch.setattr(_ExperimentPreview, "_odor_layers", odor_layers)
+    monkeypatch.setattr(_ExperimentPreview, "_border_layers", border_layers)
+
+    preview = _ExperimentPreview(_DummyPreviewLauncher(), launcher_ready=True)
+    _disable_dynamic_preview_layers(preview)
+
+    preview._draw_overlay()
+    preview._draw_overlay()
+
+    assert calls == {"source": 1, "odor": 1, "border": 1}
+
+
+def test_single_experiment_preview_image_for_tick_batches_progress_update_once() -> (
+    None
+):
+    launcher = _DummyPreviewLauncher(t=0, nsteps=8)
+    preview = _ExperimentPreview(launcher, launcher_ready=True)
+    _disable_dynamic_preview_layers(preview)
+    progress = _ProgressRecorder()
+    preview.progress_bar = progress
+
+    preview._image_for_tick(3)
+
+    assert launcher.t == 3
+    assert launcher.step_calls == 3
+    assert progress.updates == [3]
+
+
+def test_single_experiment_preview_current_tick_only_redraws() -> None:
+    def fail_step() -> None:
+        raise AssertionError("sim_step should not be called for the current tick")
+
+    launcher = _DummyPreviewLauncher(t=2, nsteps=8, step_hook=fail_step)
+    preview = _ExperimentPreview(launcher, launcher_ready=True)
+    _disable_dynamic_preview_layers(preview)
+    preview.forward_only_note.object = _ExperimentPreview._FORWARD_ONLY_MESSAGE
+    progress = _ProgressRecorder()
+    preview.progress_bar = progress
+
+    preview._image_for_tick(2)
+
+    assert launcher.step_calls == 0
+    assert preview.forward_only_note.object == ""
+    assert progress.updates == []
+
+
+def test_single_experiment_preview_backward_seek_syncs_to_current_tick() -> None:
+    def fail_step() -> None:
+        raise AssertionError("sim_step should not be called on backward seek")
+
+    launcher = _DummyPreviewLauncher(t=4, nsteps=8, step_hook=fail_step)
+    preview = _ExperimentPreview(launcher, launcher_ready=True)
+    _disable_dynamic_preview_layers(preview)
+    progress = _ProgressRecorder()
+    preview.progress_bar = progress
+
+    preview._image_for_tick(1)
+
+    assert launcher.step_calls == 0
+    assert preview.time_slider.value == 4
+    assert "forward-only" in preview.forward_only_note.object
+    assert progress.updates == [4]
 
 
 @pytest.mark.skip(reason=SINGLE_EXPERIMENT_APP_INCOMPLETE_REASON)
@@ -283,7 +429,7 @@ def test_single_experiment_run_experiment_writes_plan_and_reports_storage(
             return ["dataset_a", "dataset_b"]
 
     monkeypatch.setattr(
-        "larvaworld.portal.single_experiment_app.sim.ExpRun",
+        "larvaworld.portal.simulation.single_experiment_app.sim.ExpRun",
         DummyRun,
     )
 
@@ -326,11 +472,11 @@ def test_single_experiment_run_experiment_shows_running_state_before_deferred_ex
             return ["dataset_a"]
 
     monkeypatch.setattr(
-        "larvaworld.portal.single_experiment_app.sim.ExpRun",
+        "larvaworld.portal.simulation.single_experiment_app.sim.ExpRun",
         DummyRun,
     )
     monkeypatch.setattr(
-        "larvaworld.portal.single_experiment_app.pn.state",
+        "larvaworld.portal.simulation.single_experiment_app.pn.state",
         "curdoc",
         DummyDoc(),
         raising=False,
@@ -399,7 +545,7 @@ def test_single_experiment_run_experiment_passes_video_screen_kws(
             return ["dataset_a"]
 
     monkeypatch.setattr(
-        "larvaworld.portal.single_experiment_app.sim.ExpRun",
+        "larvaworld.portal.simulation.single_experiment_app.sim.ExpRun",
         DummyRun,
     )
 
@@ -438,7 +584,7 @@ def test_single_experiment_run_experiment_explicitly_closes_screen_manager(
             return ["dataset_a"]
 
     monkeypatch.setattr(
-        "larvaworld.portal.single_experiment_app.sim.ExpRun",
+        "larvaworld.portal.simulation.single_experiment_app.sim.ExpRun",
         DummyRun,
     )
 
@@ -474,11 +620,11 @@ def test_single_experiment_preview_status_uses_reserved_run_directory_wording(
             return "preview"
 
     monkeypatch.setattr(
-        "larvaworld.portal.single_experiment_app._SingleExperimentController._prepare_preview_launcher",
+        "larvaworld.portal.simulation.single_experiment_app._SingleExperimentController._prepare_preview_launcher",
         lambda self, experiment, parameters, run_dir: (DummyPreviewLauncher(), None),
     )
     monkeypatch.setattr(
-        "larvaworld.portal.single_experiment_app._ExperimentPreview",
+        "larvaworld.portal.simulation.single_experiment_app._ExperimentPreview",
         DummyPreview,
     )
 
@@ -517,7 +663,7 @@ def test_single_experiment_preview_launcher_falls_back_when_overlap_elimination_
         return DummyLauncher(parameters)
 
     monkeypatch.setattr(
-        "larvaworld.portal.single_experiment_app.sim.ExpRun",
+        "larvaworld.portal.simulation.single_experiment_app.sim.ExpRun",
         fake_exp_run,
     )
 

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -5,10 +5,15 @@ from pathlib import Path
 
 import holoviews as hv
 import numpy as np
+import panel as pn
 import pytest
 
 from larvaworld.lib import util
 from larvaworld.lib.reg.larvagroup import LarvaGroup
+from larvaworld.portal.canvas_widgets.environment_models import (
+    CanvasArena,
+    EnvironmentCanvasState,
+)
 from larvaworld.portal.landing_registry import ITEMS
 from larvaworld.portal.simulation.single_experiment_app import (
     _ExperimentPreview,
@@ -56,6 +61,28 @@ def test_single_experiment_lists_workspace_environment_presets(tmp_path: Path) -
     assert controller.environment_select.options["dish_custom"] == "dish_custom.json"
 
 
+def test_single_experiment_lists_and_loads_registry_environment_presets(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    controller = _SingleExperimentController()
+
+    assert "Registry / maze" in controller.environment_select.options
+    controller.experiment.value = "dish"
+    controller.environment_select.value = controller.environment_select.options[
+        "Registry / maze"
+    ]
+
+    parameters = controller._build_parameters()
+
+    assert parameters.env_params.arena.geometry == "rectangular"
+    assert "Maze" in parameters.env_params.border_list
+    assert controller._selected_environment_label() == "registry / maze"
+
+
 def test_single_experiment_build_parameters_applies_environment_override(
     tmp_path: Path,
 ) -> None:
@@ -100,6 +127,132 @@ def test_single_experiment_build_parameters_applies_environment_override(
     assert "patch" in parameters.env_params.food_params.source_units
     assert parameters.env_params.food_params.source_units["patch"]["pos"] == (0.02, 0.0)
     assert isinstance(parameters, util.AttrDict)
+
+
+def test_single_experiment_configuration_preview_does_not_call_exp_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    captured: dict[str, object] = {}
+    canvas_view = pn.pane.HTML("canvas-view")
+
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            captured["editable"] = editable
+
+        def set_state(self, state):
+            captured["state"] = state
+
+        def view(self):
+            return canvas_view
+
+    def fail_exp_run(**kwargs):
+        raise AssertionError("configuration preview should not instantiate ExpRun")
+
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.sim.ExpRun",
+        fail_exp_run,
+    )
+
+    controller = _SingleExperimentController()
+    controller.run_name.value = "dish_config_preview"
+    controller._on_prepare_preview()
+
+    assert captured["editable"] is False
+    assert "state" in captured
+    assert controller.preview[0] is canvas_view
+    assert "No simulation has been run" in controller.status.object
+
+
+def test_single_experiment_configuration_preview_uses_mapped_canvas_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    mapped_state = EnvironmentCanvasState(arena=CanvasArena("rectangular", (0.2, 0.1)))
+    captured: dict[str, object] = {}
+    canvas_view = pn.pane.HTML("canvas-view")
+
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            pass
+
+        def set_state(self, state):
+            captured["state"] = state
+
+        def view(self):
+            return canvas_view
+
+    def fake_mapping(env_params, *, larva_groups=None):
+        captured["env_params"] = env_params
+        captured["larva_groups"] = larva_groups
+        return mapped_state
+
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.env_params_to_canvas_state",
+        fake_mapping,
+    )
+
+    controller = _SingleExperimentController()
+    controller._on_prepare_preview()
+
+    assert captured["state"] is mapped_state
+    assert captured["env_params"] is not None
+    assert captured["larva_groups"] is not None
+    assert controller.preview[0] is canvas_view
+
+
+def test_single_experiment_configuration_preview_uses_environment_preset_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+    (workspace_root / "environments" / "rect_env.json").write_text(
+        json.dumps({"arena": {"geometry": "rectangular", "dims": [0.2, 0.1]}}) + "\n",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            pass
+
+        def set_state(self, state):
+            captured["state"] = state
+
+        def view(self):
+            return "canvas-view"
+
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+
+    controller = _SingleExperimentController()
+    controller.environment_select.value = "rect_env.json"
+    controller._on_prepare_preview()
+
+    state = captured["state"]
+    assert state.arena.geometry == "rectangular"
+    assert state.arena.dims == (0.2, 0.1)
 
 
 def test_single_experiment_builder_obstacles_are_translated_into_border_entries(
@@ -630,7 +783,7 @@ def test_single_experiment_preview_status_uses_reserved_run_directory_wording(
 
     controller = _SingleExperimentController()
     controller.run_name.value = "dish_preview"
-    controller._on_prepare_preview()
+    controller._on_generate_simulation_preview()
 
     assert "Reserved output directory for a future run" in controller.status.object
 

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -941,7 +941,7 @@ def test_single_experiment_generate_preview_uses_resolved_parameters_boundary(
     controller._on_generate_simulation_preview()
 
 
-def test_frame_simulation_preview_slider_is_random_access() -> None:
+def test_frame_simulation_preview_player_is_random_access() -> None:
     class DummyCanvas:
         def __init__(self):
             self.applied_ticks: list[int] = []
@@ -964,12 +964,160 @@ def test_frame_simulation_preview_slider_is_random_access() -> None:
     )
 
     assert canvas.applied_ticks == [0]
-    preview.frame_slider.value = 2
-    preview.frame_slider.value = 1
+    preview.frame_player.value = 2
+    preview.frame_player.value = 1
 
     assert canvas.applied_ticks == [0, 2, 1]
     assert "Frame:</strong> 1/2" in preview.metadata.object
     assert "Tick:</strong> 1" in preview.metadata.object
+
+
+def test_frame_simulation_preview_show_frame_clamps_indices() -> None:
+    class DummyCanvas:
+        def __init__(self):
+            self.applied_ticks: list[int] = []
+
+        def set_larva_frame(self, frame: LarvaPreviewFrame) -> None:
+            self.applied_ticks.append(frame.tick)
+
+        def view(self):
+            return pn.pane.HTML("canvas")
+
+    canvas = DummyCanvas()
+    preview = _FrameSimulationPreview(
+        canvas=canvas,
+        frames=[
+            LarvaPreviewFrame(tick=0, centroids=((0.0, 0.0),)),
+            LarvaPreviewFrame(tick=1, centroids=((0.01, 0.01),)),
+            LarvaPreviewFrame(tick=2, centroids=((0.02, 0.02),)),
+        ],
+        dt=0.1,
+    )
+
+    preview._show_frame(-1)
+    preview._show_frame(999)
+
+    assert canvas.applied_ticks == [0, 0, 2]
+    assert int(preview.frame_player.value) == 2
+    assert "Frame:</strong> 2/2" in preview.metadata.object
+    assert "Tick:</strong> 2" in preview.metadata.object
+
+
+def test_generate_preview_uses_requested_preview_frame_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    captured: dict[str, object] = {}
+
+    class DummyPreviewLauncher:
+        def __init__(self):
+            self.p = util.AttrDict({"steps": 500})
+            self.dt = 0.1
+
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            pass
+
+        def set_state(self, state):
+            captured["state"] = state
+
+        def set_larva_frame(self, frame):
+            captured["frame"] = frame
+
+        def view(self):
+            return pn.pane.HTML("canvas")
+
+    def fake_generate_preview_frames(launcher, preview_steps, **kwargs):
+        captured["preview_steps"] = preview_steps
+        return [LarvaPreviewFrame(tick=0, centroids=((0.0, 0.0),))]
+
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app._SingleExperimentController._prepare_preview_launcher",
+        lambda self, experiment, parameters, run_dir: (DummyPreviewLauncher(), None),
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.generate_preview_frames",
+        fake_generate_preview_frames,
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+
+    controller = _SingleExperimentController()
+    controller.preview_frames_input.value = 120
+    controller._on_generate_simulation_preview()
+
+    assert captured["preview_steps"] == 120
+
+
+def test_generate_preview_caps_requested_frames_by_launcher_steps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    captured: dict[str, object] = {}
+
+    class DummyPreviewLauncher:
+        def __init__(self):
+            self.p = util.AttrDict({"steps": 7})
+            self.dt = 0.1
+
+    class DummyCanvas:
+        def __init__(self, *, editable=False):
+            pass
+
+        def set_state(self, state):
+            captured["state"] = state
+
+        def set_larva_frame(self, frame):
+            captured["frame"] = frame
+
+        def view(self):
+            return pn.pane.HTML("canvas")
+
+    def fake_generate_preview_frames(launcher, preview_steps, **kwargs):
+        captured["preview_steps"] = preview_steps
+        return [LarvaPreviewFrame(tick=0, centroids=((0.0, 0.0),))]
+
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app._SingleExperimentController._prepare_preview_launcher",
+        lambda self, experiment, parameters, run_dir: (DummyPreviewLauncher(), None),
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.generate_preview_frames",
+        fake_generate_preview_frames,
+    )
+    monkeypatch.setattr(
+        "larvaworld.portal.simulation.single_experiment_app.EnvironmentCanvas",
+        DummyCanvas,
+    )
+
+    controller = _SingleExperimentController()
+    controller.preview_frames_input.value = 120
+    controller._on_generate_simulation_preview()
+
+    assert captured["preview_steps"] == 7
+
+
+def test_single_experiment_action_rows_separate_preview_and_execution() -> None:
+    controller = _SingleExperimentController()
+
+    assert controller.prepare_btn in controller.preview_action_row.objects
+    assert (
+        controller.simulation_preview_btn not in controller.preview_action_row.objects
+    )
+    assert controller.run_btn not in controller.preview_action_row.objects
+    assert controller.preview_frames_input in controller.preview_options_row.objects
+    assert controller.simulation_preview_btn in controller.preview_generate_row.objects
+    assert controller.run_btn in controller.execution_action_row.objects
 
 
 def test_generate_preview_uses_show_group_shapes_false(

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -8,7 +8,7 @@ import numpy as np
 import panel as pn
 import pytest
 
-from larvaworld.lib import util
+from larvaworld.lib import reg, util
 from larvaworld.lib.reg.larvagroup import LarvaGroup
 from larvaworld.portal.canvas_widgets.environment_models import (
     CanvasArena,
@@ -57,8 +57,11 @@ def test_single_experiment_lists_workspace_environment_presets(tmp_path: Path) -
     controller = _SingleExperimentController()
 
     assert (
-        controller.environment_select.options["Template default environment"]
-        == "__template__"
+        controller.environment_select.options["Template default: dish"] == "__template__"
+    )
+    assert (
+        controller.environment_select.options["Registry / dish [template default]"]
+        == "__registry__:dish"
     )
     assert controller.environment_select.options["dish_custom"] == "dish_custom.json"
 
@@ -83,6 +86,41 @@ def test_single_experiment_lists_and_loads_registry_environment_presets(
     assert parameters.env_params.arena.geometry == "rectangular"
     assert "Maze" in parameters.env_params.border_list
     assert controller._selected_environment_label() == "registry / maze"
+
+
+def test_single_experiment_template_change_auto_refreshes_environment_presets(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    controller = _SingleExperimentController()
+    current_template = str(controller.experiment.value)
+    env_ids = set(str(env_id) for env_id in reg.conf.Env.confIDs)
+    candidate = next(
+        (
+            exp_id
+            for exp_id in (str(exp_id) for exp_id in reg.conf.Exp.confIDs)
+            if exp_id in env_ids and exp_id != current_template
+        ),
+        None,
+    )
+    if candidate is None:
+        pytest.skip("No experiment template with matching environment ID available")
+
+    controller.experiment.value = candidate
+
+    assert (
+        controller.environment_select.options[f"Template default: {candidate}"]
+        == "__template__"
+    )
+    assert (
+        controller.environment_select.options[
+            f"Registry / {candidate} [template default]"
+        ]
+        == f"__registry__:{candidate}"
+    )
 
 
 def test_single_experiment_build_parameters_applies_environment_override(

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -57,7 +57,8 @@ def test_single_experiment_lists_workspace_environment_presets(tmp_path: Path) -
     controller = _SingleExperimentController()
 
     assert (
-        controller.environment_select.options["Template default: dish"] == "__template__"
+        controller.environment_select.options["Template default: dish"]
+        == "__template__"
     )
     assert (
         controller.environment_select.options["Registry / dish [template default]"]

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -706,17 +706,37 @@ def test_single_experiment_runtime_screen_kws_include_video_when_enabled(
     controller = _SingleExperimentController()
     controller.save_video.value = True
     controller.video_filename.value = "dish_video"
-    controller.video_fps.value = 24
+    controller.video_fps.value = 3
     controller.show_display.value = True
+    controller.display_every_n_steps.value = 4
 
     kws = controller._runtime_screen_kws(workspace_root / "experiments" / "dish_demo")
 
+    assert controller.video_fps.name == "Video speed-up"
     assert kws["save_video"] is True
     assert kws["vis_mode"] == "video"
     assert kws["video_file"] == "dish_video"
-    assert kws["fps"] == 24
+    assert kws["fps"] == 3
     assert kws["show_display"] is True
+    assert kws["display_every_n_steps"] == 4
     assert kws["media_dir"] == str(workspace_root / "experiments" / "dish_demo")
+
+
+def test_single_experiment_show_display_uses_video_render_mode(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    initialize_workspace(workspace_root)
+    set_active_workspace_path(workspace_root)
+
+    controller = _SingleExperimentController()
+    controller.show_display.value = True
+    controller.display_every_n_steps.value = 3
+
+    kws = controller._runtime_screen_kws(workspace_root / "experiments" / "dish_demo")
+
+    assert kws["show_display"] is True
+    assert kws["vis_mode"] == "video"
+    assert kws["display_every_n_steps"] == 3
+    assert "save_video" not in kws
 
 
 def test_single_experiment_run_experiment_passes_video_screen_kws(
@@ -745,13 +765,36 @@ def test_single_experiment_run_experiment_passes_video_screen_kws(
     controller.run_name.value = "dish_demo"
     controller.save_video.value = True
     controller.video_filename.value = "dish_capture"
-    controller.video_fps.value = 25
+    controller.video_fps.value = 5
+    controller.display_every_n_steps.value = 6
     controller._on_run_experiment()
 
     assert captured["screen_kws"]["save_video"] is True
     assert captured["screen_kws"]["video_file"] == "dish_capture"
-    assert captured["screen_kws"]["fps"] == 25
+    assert captured["screen_kws"]["fps"] == 5
+    assert captured["screen_kws"]["display_every_n_steps"] == 6
     assert "dish_capture.mp4" in controller.status.object
+
+
+def test_single_experiment_video_speed_up_defaults_to_realtime() -> None:
+    controller = _SingleExperimentController()
+
+    assert controller.video_fps.name == "Video speed-up"
+    assert controller.video_fps.value == 1
+    assert "simulated real time" in controller.video_fps.description
+    assert "twice as fast" in controller.video_fps.description
+    assert "one fifth as long" in controller.video_fps.description
+
+
+def test_single_experiment_display_every_n_steps_follows_show_display() -> None:
+    controller = _SingleExperimentController()
+
+    assert controller.display_every_n_steps.value == 1
+    assert controller.display_every_n_steps.disabled is True
+    controller.show_display.value = True
+    assert controller.display_every_n_steps.disabled is False
+    controller.show_display.value = False
+    assert controller.display_every_n_steps.disabled is True
 
 
 def test_single_experiment_run_experiment_explicitly_closes_screen_manager(

--- a/tests/unit/portal/test_single_experiment_app.py
+++ b/tests/unit/portal/test_single_experiment_app.py
@@ -1192,6 +1192,7 @@ def test_generate_preview_uses_show_group_shapes_false(
             return pn.pane.HTML("canvas")
 
     def fake_mapping(env_params, *, larva_groups=None, show_group_shapes=True):
+        captured["larva_groups"] = larva_groups
         captured["show_group_shapes"] = show_group_shapes
         return EnvironmentCanvasState(arena=CanvasArena("rectangular", (0.1, 0.1)))
 
@@ -1217,6 +1218,7 @@ def test_generate_preview_uses_show_group_shapes_false(
     controller = _SingleExperimentController()
     controller._on_generate_simulation_preview()
 
+    assert captured["larva_groups"] is None
     assert captured["show_group_shapes"] is False
 
 

--- a/tests/unit/portal/test_single_experiment_preview_frames.py
+++ b/tests/unit/portal/test_single_experiment_preview_frames.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from math import isnan
+from types import SimpleNamespace
+
+from larvaworld.portal.canvas_widgets.environment_models import LarvaPreviewFrame
+from larvaworld.portal.simulation.preview_frames import (
+    capture_larva_frame,
+    generate_preview_frames,
+)
+
+
+class DummyAgent:
+    def __init__(
+        self,
+        *,
+        pos,
+        head,
+        midline,
+        trajectory,
+        color,
+    ) -> None:
+        self.pos = pos
+        self.head = head
+        self.midline_xy = midline
+        self.trajectory = trajectory
+        self.color = color
+
+
+class DummyAgents(list):
+    def get_position(self):
+        return [agent.pos for agent in self]
+
+    @property
+    def head(self):
+        return SimpleNamespace(front_end=[agent.head for agent in self])
+
+
+class DummyLauncher:
+    def __init__(self, agents, *, tick: int = 0) -> None:
+        self.agents = DummyAgents(agents)
+        self.t = tick
+        self.step_calls = 0
+
+    def sim_step(self) -> None:
+        self.t += 1
+        self.step_calls += 1
+        for agent in self.agents:
+            if isinstance(agent.pos, list) and len(agent.pos) >= 2:
+                agent.pos[0] += 1.0
+                agent.pos[1] += 1.0
+            if isinstance(agent.trajectory, list):
+                agent.trajectory.append(tuple(agent.pos))
+
+
+def test_capture_larva_frame_copies_expected_fields() -> None:
+    launcher = DummyLauncher(
+        [
+            DummyAgent(
+                pos=[0.0, 0.0],
+                head=[0.001, 0.002],
+                midline=[(0.0, 0.0), (0.001, 0.002)],
+                trajectory=[(0.0, 0.0), (0.001, 0.001), (0.002, 0.002)],
+                color="#111111",
+            ),
+            DummyAgent(
+                pos=[0.01, 0.02],
+                head=[0.011, 0.022],
+                midline=[(0.01, 0.02), (0.012, 0.021)],
+                trajectory=[(0.01, 0.02), (0.015, 0.025)],
+                color="#222222",
+            ),
+        ],
+        tick=7,
+    )
+
+    frame = capture_larva_frame(launcher, trail_length=2)
+
+    assert isinstance(frame, LarvaPreviewFrame)
+    assert frame.tick == 7
+    assert frame.centroids == ((0.0, 0.0), (0.01, 0.02))
+    assert frame.heads == ((0.001, 0.002), (0.011, 0.022))
+    assert frame.midlines == (
+        ((0.0, 0.0), (0.001, 0.002)),
+        ((0.01, 0.02), (0.012, 0.021)),
+    )
+    assert frame.trails == (
+        ((0.001, 0.001), (0.002, 0.002)),
+        ((0.01, 0.02), (0.015, 0.025)),
+    )
+    assert frame.colors == ("#111111", "#222222")
+
+
+def test_capture_larva_frame_preserves_alignment_for_invalid_optional_data() -> None:
+    launcher = DummyLauncher(
+        [
+            DummyAgent(
+                pos=[0.0, 0.0],
+                head=[0.001, 0.002],
+                midline=[(0.0, 0.0), (0.001, 0.002)],
+                trajectory=[(0.0, 0.0), (0.001, 0.001)],
+                color="#111111",
+            ),
+            DummyAgent(
+                pos=[0.02, 0.03],
+                head=["bad", None],
+                midline=[(0.02, 0.03)],
+                trajectory=[(0.02, 0.03)],
+                color=None,
+            ),
+            DummyAgent(
+                pos=[0.04, 0.05],
+                head=[0.041, 0.052],
+                midline=[(0.04, 0.05), (0.041, 0.052)],
+                trajectory=[(0.04, 0.05), (0.042, 0.054)],
+                color="#333333",
+            ),
+        ]
+    )
+
+    frame = capture_larva_frame(launcher, trail_length=5)
+
+    assert len(frame.centroids) == 3
+    assert len(frame.heads) == 3
+    assert len(frame.midlines) == 3
+    assert len(frame.trails) == 3
+    assert len(frame.colors) == 3
+
+    assert frame.heads[0] == (0.001, 0.002)
+    assert isnan(frame.heads[1][0]) and isnan(frame.heads[1][1])
+    assert frame.heads[2] == (0.041, 0.052)
+
+    assert frame.midlines[0] == ((0.0, 0.0), (0.001, 0.002))
+    assert frame.midlines[1] == ((0.02, 0.03),)
+    assert frame.midlines[2] == ((0.04, 0.05), (0.041, 0.052))
+
+    assert frame.trails[0] == ((0.0, 0.0), (0.001, 0.001))
+    assert frame.trails[1] == ((0.02, 0.03),)
+    assert frame.trails[2] == ((0.04, 0.05), (0.042, 0.054))
+
+    assert frame.colors == ("#111111", "", "#333333")
+
+
+def test_capture_larva_frame_returns_empty_frame_for_empty_agents() -> None:
+    frame = capture_larva_frame(DummyLauncher([], tick=3))
+    assert frame == LarvaPreviewFrame(tick=3)
+
+
+def test_capture_larva_frame_copies_values_not_references() -> None:
+    agent = DummyAgent(
+        pos=[0.0, 0.0],
+        head=[0.001, 0.002],
+        midline=[(0.0, 0.0), (0.001, 0.001)],
+        trajectory=[(0.0, 0.0), (0.001, 0.001)],
+        color="#111111",
+    )
+    launcher = DummyLauncher([agent], tick=5)
+
+    frame = capture_larva_frame(launcher)
+
+    agent.pos[0] = 9.9
+    agent.head[0] = 8.8
+    agent.midline_xy[0] = (7.7, 7.7)
+    agent.trajectory[0] = (6.6, 6.6)
+
+    assert frame.centroids == ((0.0, 0.0),)
+    assert frame.heads == ((0.001, 0.002),)
+    assert frame.midlines == (((0.0, 0.0), (0.001, 0.001)),)
+    assert frame.trails == (((0.0, 0.0), (0.001, 0.001)),)
+
+
+def test_capture_larva_frame_tick_override() -> None:
+    launcher = DummyLauncher(
+        [
+            DummyAgent(
+                pos=[0.0, 0.0],
+                head=[0.0, 0.0],
+                midline=[],
+                trajectory=[],
+                color="black",
+            )
+        ],
+        tick=4,
+    )
+    frame = capture_larva_frame(launcher, tick=99)
+    assert frame.tick == 99
+
+
+def test_generate_preview_frames_returns_exact_count_and_steps() -> None:
+    launcher = DummyLauncher(
+        [
+            DummyAgent(
+                pos=[0.0, 0.0],
+                head=[0.001, 0.002],
+                midline=[(0.0, 0.0), (0.001, 0.001)],
+                trajectory=[(0.0, 0.0), (0.001, 0.001)],
+                color="#111111",
+            )
+        ],
+        tick=0,
+    )
+
+    frames = generate_preview_frames(launcher, preview_steps=5)
+
+    assert len(frames) == 5
+    assert launcher.step_calls == 4
+    assert [frame.tick for frame in frames] == [0, 1, 2, 3, 4]
+
+
+def test_generate_preview_frames_returns_empty_list_for_non_positive_steps() -> None:
+    launcher = DummyLauncher([], tick=10)
+    assert generate_preview_frames(launcher, preview_steps=0) == []
+    assert generate_preview_frames(launcher, preview_steps=-3) == []
+    assert launcher.step_calls == 0

--- a/tests/unit/sim/test_screen_drawing.py
+++ b/tests/unit/sim/test_screen_drawing.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from larvaworld.lib.screen.drawing import ScreenManager
+
+
+def test_screen_manager_render_display_only_skips_array3d(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"flip": 0}
+
+    def _flip() -> None:
+        calls["flip"] += 1
+
+    monkeypatch.setattr("pygame.display.flip", _flip)
+    monkeypatch.setattr(
+        "pygame.surfarray.array3d",
+        lambda *_: (_ for _ in ()).throw(AssertionError("array3d should not run")),
+    )
+
+    manager = SimpleNamespace(
+        show_display=True,
+        vid_writer=None,
+        img_writer=None,
+        v=object(),
+    )
+
+    image = ScreenManager._render(manager)
+
+    assert image is None
+    assert calls["flip"] == 1
+
+
+def test_screen_manager_render_media_path_keeps_array3d(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"flip": 0, "array3d": 0}
+    array = np.zeros((2, 2, 3), dtype=np.uint8)
+    frames: list[np.ndarray] = []
+
+    class DummyWriter:
+        def append_data(self, frame: np.ndarray) -> None:
+            frames.append(frame)
+
+    def _flip() -> None:
+        calls["flip"] += 1
+
+    def _array3d(*_: object) -> np.ndarray:
+        calls["array3d"] += 1
+        return array
+
+    monkeypatch.setattr("pygame.display.flip", _flip)
+    monkeypatch.setattr("pygame.surfarray.array3d", _array3d)
+
+    manager = SimpleNamespace(
+        show_display=True,
+        vid_writer=DummyWriter(),
+        img_writer=None,
+        v=object(),
+    )
+
+    image = ScreenManager._render(manager)
+
+    assert image is array
+    assert calls["flip"] == 1
+    assert calls["array3d"] == 1
+    assert len(frames) == 1
+
+
+def test_screen_manager_render_decimation_keeps_input_responsive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {
+        "check": 0,
+        "evaluate_input": 0,
+        "evaluate_graphs": 0,
+        "draw_arena": 0,
+        "draw_agents": 0,
+        "draw_overlay": 0,
+        "draw_aux": 0,
+        "render": 0,
+    }
+
+    monkeypatch.setattr("pygame.display.get_init", lambda: True)
+
+    manager = SimpleNamespace(
+        active=True,
+        closed=False,
+        overlap_mode=False,
+        show_display=True,
+        display_only_mode=True,
+        should_draw_live_frame=False,
+        tank_color=(255, 255, 255),
+        screen_color=(0, 0, 0),
+    )
+    manager.check = lambda **_: calls.__setitem__("check", calls["check"] + 1)
+    manager.evaluate_input = lambda: calls.__setitem__(
+        "evaluate_input", calls["evaluate_input"] + 1
+    )
+    manager.evaluate_graphs = lambda: calls.__setitem__(
+        "evaluate_graphs", calls["evaluate_graphs"] + 1
+    )
+    manager.draw_arena = lambda: calls.__setitem__(
+        "draw_arena", calls["draw_arena"] + 1
+    )
+    manager.draw_agents = lambda: calls.__setitem__(
+        "draw_agents", calls["draw_agents"] + 1
+    )
+    manager._draw_arena = lambda *_: calls.__setitem__(
+        "draw_overlay", calls["draw_overlay"] + 1
+    )
+    manager.draw_aux = lambda: calls.__setitem__("draw_aux", calls["draw_aux"] + 1)
+    manager._render = lambda: calls.__setitem__("render", calls["render"] + 1)
+
+    ScreenManager.render(manager)
+
+    assert calls["check"] == 1
+    assert calls["evaluate_input"] == 1
+    assert calls["evaluate_graphs"] == 1
+    assert calls["draw_arena"] == 0
+    assert calls["draw_agents"] == 0
+    assert calls["draw_overlay"] == 0
+    assert calls["draw_aux"] == 0
+    assert calls["render"] == 0
+
+
+def test_screen_manager_render_does_not_decimate_media_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {
+        "check": 0,
+        "evaluate_input": 0,
+        "evaluate_graphs": 0,
+        "draw_arena": 0,
+        "draw_agents": 0,
+        "draw_overlay": 0,
+        "draw_aux": 0,
+        "render": 0,
+    }
+
+    monkeypatch.setattr("pygame.display.get_init", lambda: True)
+
+    manager = SimpleNamespace(
+        active=True,
+        closed=False,
+        overlap_mode=False,
+        show_display=True,
+        display_only_mode=False,
+        should_draw_live_frame=False,
+        tank_color=(255, 255, 255),
+        screen_color=(0, 0, 0),
+    )
+    manager.check = lambda **_: calls.__setitem__("check", calls["check"] + 1)
+    manager.evaluate_input = lambda: calls.__setitem__(
+        "evaluate_input", calls["evaluate_input"] + 1
+    )
+    manager.evaluate_graphs = lambda: calls.__setitem__(
+        "evaluate_graphs", calls["evaluate_graphs"] + 1
+    )
+    manager.draw_arena = lambda: calls.__setitem__(
+        "draw_arena", calls["draw_arena"] + 1
+    )
+    manager.draw_agents = lambda: calls.__setitem__(
+        "draw_agents", calls["draw_agents"] + 1
+    )
+    manager._draw_arena = lambda *_: calls.__setitem__(
+        "draw_overlay", calls["draw_overlay"] + 1
+    )
+    manager.draw_aux = lambda: calls.__setitem__("draw_aux", calls["draw_aux"] + 1)
+    manager._render = lambda: calls.__setitem__("render", calls["render"] + 1)
+
+    ScreenManager.render(manager)
+
+    assert calls["check"] == 1
+    assert calls["evaluate_input"] == 1
+    assert calls["evaluate_graphs"] == 1
+    assert calls["draw_arena"] == 1
+    assert calls["draw_agents"] == 1
+    assert calls["draw_overlay"] == 1
+    assert calls["draw_aux"] == 1
+    assert calls["render"] == 1
+
+
+def test_screen_manager_display_mode_helpers() -> None:
+    manager = SimpleNamespace(
+        show_display=True,
+        save_video=False,
+        image_mode=None,
+        vid_writer=None,
+        img_writer=None,
+        display_every_n_steps=3,
+        model=SimpleNamespace(Nticks=1),
+    )
+
+    assert ScreenManager.display_only_mode.fget(manager) is True
+    assert ScreenManager.should_draw_live_frame.fget(manager) is False
+
+    manager.model.Nticks = 3
+    assert ScreenManager.should_draw_live_frame.fget(manager) is True
+
+    manager.save_video = True
+    assert ScreenManager.display_only_mode.fget(manager) is False


### PR DESCRIPTION
## Summary

This PR completes the M2C follow-up stream for the portal work and fixes the release publishing workflow.

It consolidates the Single Experiment portal app under `portal/simulation/`, adds the shared environment canvas rendering layer, replaces the old simulation preview path with frame-based playback, refines dataset/config workflows, improves live display performance, and splits release publishing into a tag-triggered workflow so PyPI uploads are not skipped after semantic-release creates a tag.

## Main Changes

- Move Single Experiment into `src/larvaworld/portal/simulation/` and update portal routing.
- Add shared `portal/canvas_widgets/` models, mapping helpers, and `EnvironmentCanvas`.
- Add frame capture helpers and frame-based Single Experiment preview playback.
- Polish Single Experiment preview controls, visuals, runtime defaults, preset selection, and arena summaries.
- Optimize live display rendering with display-only `array3d` bypass and redraw decimation.
- Refine Import Experimental Datasets layout and config widget action handling.
- Add dedicated helpers for conftype actions and enrichment config widgets.
- Harden intermitter state helper behavior.
- Fix source-group legend/canvas rendering wiring.
- Split release flow:
  - `ci.yml` now handles semantic-release versioning, changelog, release commit, and tag creation.
  - `publish.yml` now publishes built distributions to PyPI and GitHub Releases from `v*` tag pushes.

## Why

The portal changes make Single Experiment previews faster, more testable, and aligned with the shared canvas rendering direction used by the M2 portal apps.

The release workflow change fixes the issue where GitHub could have a release tag while PyPI remained behind. The previous flow depended on `steps.release.outputs.released == 'true'`; if semantic-release saw an existing tag, the PyPI publish step was skipped. Publishing from tag pushes makes the release tag the source of truth.

## Testing / Verification

- Focused portal tests across Single Experiment, dataset import, config actions, enrichment widgets, environment canvas, environment mapping, preview frames, and screen drawing.
- Focused py_compile checks for touched portal modules.
- Pre-commit on the changed portal and workflow files.
- Workflow validation:
  - `pre-commit run --files .github/workflows/ci.yml .github/workflows/publish.yml`
  - YAML parse check for `ci.yml` and `publish.yml`
  - `git diff --check -- .github/workflows/ci.yml .github/workflows/publish.yml`